### PR TITLE
Improve Works section publication ordering and Scholar reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,8 @@
     <!-- Works Section -->
 <section id="works" class="py-20 bg-primaryDark text-gray-100 relative" style="background-image: linear-gradient(rgba(40,63,35,0.85), rgba(40,63,35,0.85)), url('assets/img/publications.JPG'); background-size: cover; background-position: center; background-repeat: no-repeat;" data-aos="fade-up">
       <div class="max-w-6xl mx-auto px-4">
-          <h2 class="text-3xl font-semibold mb-10 text-accent2">Works</h2>
+          <h2 class="text-3xl font-semibold mb-4 text-accent2">Works</h2>
+          <p class="text-sm text-gray-300 mb-6">Publications are arranged by type and sorted by latest year/date for easier browsing. For the most current citation profile, view Google Scholar: <a href="https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en" target="_blank" class="text-accent2 hover:text-accent underline">PV8dJDkAAAAJ</a>.</p>
           <!-- Removed static Top Works section to rely on dynamic publications -->
           <!-- Tabs -->
           <div class="tabs flex flex-col sm:flex-row gap-4 mb-8">

--- a/js/script.js
+++ b/js/script.js
@@ -412,13 +412,28 @@ const closedAccessIconClass = 'ai ai-closed-access';
  * @param {string} countId - id of span to show total count (optional)
  */
 function initSection(data, containerId, searchId, filterId, countId) {
+  const normalizedData = [...data].sort((a, b) => {
+    const yearDiff = Number(b.year || 0) - Number(a.year || 0);
+    if (yearDiff !== 0) return yearDiff;
+
+    const dateA = a.date ? Date.parse(a.date) : Number.NaN;
+    const dateB = b.date ? Date.parse(b.date) : Number.NaN;
+    const hasDateA = Number.isFinite(dateA);
+    const hasDateB = Number.isFinite(dateB);
+
+    if (hasDateA && hasDateB && dateB !== dateA) return dateB - dateA;
+    if (hasDateA && !hasDateB) return -1;
+    if (!hasDateA && hasDateB) return 1;
+
+    return (a.title || '').localeCompare(b.title || '');
+  });
   const container = document.getElementById(containerId);
   const searchInput = document.getElementById(searchId);
   const yearSelect = document.getElementById(filterId);
   const countSpan = document.getElementById(countId);
 
   // Populate year dropdown with unique years
-  const years = Array.from(new Set(data.map((d) => d.year))).sort((a, b) => b - a);
+  const years = Array.from(new Set(normalizedData.map((d) => d.year))).sort((a, b) => b - a);
   years.forEach((y) => {
     const opt = document.createElement('option');
     opt.value = y;
@@ -428,7 +443,7 @@ function initSection(data, containerId, searchId, filterId, countId) {
 
   // Show total count if applicable
   if (countSpan) {
-    countSpan.textContent = data.length;
+    countSpan.textContent = normalizedData.length;
   }
 
   // Render publication cards
@@ -442,6 +457,7 @@ function initSection(data, containerId, searchId, filterId, countId) {
       let html = '<div class="publication-card card h-100">';
       html += '<div class="card-body">';
       html += `<h5 class="card-title">${entry.title}</h5>`;
+      html += `<p class="text-sm text-accent2 mb-2"><i class="fa-regular fa-calendar me-1"></i>${entry.year}</p>`;
       // Build citation text
       let citation = `${entry.authors}, “${entry.title},” `;
       if (entry.journal) {
@@ -501,7 +517,7 @@ function initSection(data, containerId, searchId, filterId, countId) {
   }
 
   // Initial render
-  renderCards(data);
+  renderCards(normalizedData);
 
   // Search and filter logic
   function applyFilter() {


### PR DESCRIPTION
### Motivation
- Ensure the `#works` page presents publications in a clear, consistent chronological order so visitors can browse the latest outputs first.
- Surface a direct link to the Google Scholar profile (`PV8dJDkAAAAJ`) for an authoritative, up-to-date citation record.
- Make year information more visible on each publication card and ensure year filters/counts reflect the displayed ordering.

### Description
- Updated `index.html` to shorten the Works heading area and add a descriptive paragraph with a link to the Google Scholar profile `PV8dJDkAAAAJ`.
- Modified `js/script.js` to create a `normalizedData` array and sort it by year (desc), parsed `date` (desc when available), and `title` as a final tiebreaker before rendering.
- Switched year dropdown population and publication count to use `normalizedData`, added a visible year chip (`<p class="text-sm text-accent2">`) on each publication card, and rendered from the sorted data set.

### Testing
- No automated tests were run for this change.