### PR TITLE
Publications UI: add publisher filters, sorting, counts, and update data/UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,8 @@
     <!-- Works Section -->
 <section id="works" class="py-20 bg-primaryDark text-gray-100 relative" style="background-image: linear-gradient(rgba(40,63,35,0.85), rgba(40,63,35,0.85)), url('assets/img/publications.JPG'); background-size: cover; background-position: center; background-repeat: no-repeat;" data-aos="fade-up">
       <div class="max-w-6xl mx-auto px-4">
-          <h2 class="text-3xl font-semibold mb-10 text-accent2">Works</h2>
+          <h2 class="text-3xl font-semibold mb-4 text-accent2">Works</h2>
+          <p class="text-sm text-gray-300 mb-6">Publications are arranged by type and sorted by latest year/date for easier browsing. For the most current citation profile, view Google Scholar: <a href="https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en" target="_blank" class="text-accent2 hover:text-accent underline">PV8dJDkAAAAJ</a>.</p>
           <!-- Removed static Top Works section to rely on dynamic publications -->
           <!-- Tabs -->
           <div class="tabs flex flex-col sm:flex-row gap-4 mb-8">
@@ -593,32 +594,62 @@
           </div>
           <!-- Journals -->
           <div id="journal-tab" class="tab-content">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="journal-search" type="text" placeholder="Search journal publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="journal-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="journal-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="journal-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="journal-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="journal-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="journal-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
           <!-- Conferences -->
           <div id="conference-tab" class="tab-content hidden">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="conf-search" type="text" placeholder="Search conference publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="conf-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="conf-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="conf-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="conf-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="conf-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="conference-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
           <!-- Chapters -->
           <div id="chapters-tab" class="tab-content hidden">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="chapters-search" type="text" placeholder="Search book chapters…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="chapters-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="chapters-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="chapters-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="chapters-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="chapters-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="book-chapters" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
       </div>

--- a/js/script.js
+++ b/js/script.js
@@ -10,6 +10,18 @@
 
 const journalData = [
   {
+    year: 2026,
+    authors: "FJP Montalbo",
+    title:
+      "MHADFormer: A cost-efficient multiscale hybrid transformer mixer model for automating Alzheimer’s disease diagnosis from MRI scans",
+    journal: "Applied Soft Computing",
+    date: "2026",
+    doi: "10.1016/j.asoc.2026.114624",
+    doiUrl: "https://doi.org/10.1016/j.asoc.2026.114624",
+    codeUrl: "https://github.com/francismontalbo/mhadformer",
+    publisher: "Elsevier"
+  },
+  {
     year: 2025,
     authors: "FJP Montalbo",
     title:
@@ -411,24 +423,50 @@ const closedAccessIconClass = 'ai ai-closed-access';
  * @param {string} filterId - id of year filter select
  * @param {string} countId - id of span to show total count (optional)
  */
-function initSection(data, containerId, searchId, filterId, countId) {
+function initSection(data, containerId, searchId, filterId, countId, publisherFilterId, sortId, clearId, resultsCountId) {
+  const normalizedData = [...data].sort((a, b) => {
+    const yearDiff = Number(b.year || 0) - Number(a.year || 0);
+    if (yearDiff !== 0) return yearDiff;
+
+    const dateA = a.date ? Date.parse(a.date) : Number.NaN;
+    const dateB = b.date ? Date.parse(b.date) : Number.NaN;
+    const hasDateA = Number.isFinite(dateA);
+    const hasDateB = Number.isFinite(dateB);
+
+    if (hasDateA && hasDateB && dateB !== dateA) return dateB - dateA;
+    if (hasDateA && !hasDateB) return -1;
+    if (!hasDateA && hasDateB) return 1;
+
+    return (a.title || '').localeCompare(b.title || '');
+  });
   const container = document.getElementById(containerId);
   const searchInput = document.getElementById(searchId);
   const yearSelect = document.getElementById(filterId);
+  const publisherSelect = document.getElementById(publisherFilterId);
+  const sortSelect = document.getElementById(sortId);
+  const clearButton = document.getElementById(clearId);
+  const resultsCount = document.getElementById(resultsCountId);
   const countSpan = document.getElementById(countId);
 
   // Populate year dropdown with unique years
-  const years = Array.from(new Set(data.map((d) => d.year))).sort((a, b) => b - a);
+  const years = Array.from(new Set(normalizedData.map((d) => d.year))).sort((a, b) => b - a);
   years.forEach((y) => {
     const opt = document.createElement('option');
     opt.value = y;
     opt.textContent = y;
     yearSelect.appendChild(opt);
   });
+  const publishers = Array.from(new Set(normalizedData.map((d) => d.publisher).filter(Boolean))).sort();
+  publishers.forEach((publisher) => {
+    const opt = document.createElement('option');
+    opt.value = publisher;
+    opt.textContent = publisher;
+    publisherSelect.appendChild(opt);
+  });
 
   // Show total count if applicable
   if (countSpan) {
-    countSpan.textContent = data.length;
+    countSpan.textContent = normalizedData.length;
   }
 
   // Render publication cards
@@ -438,10 +476,12 @@ function initSection(data, containerId, searchId, filterId, countId) {
       const col = document.createElement('div');
       col.className = 'col-md-6';
       col.setAttribute('data-year', entry.year);
-      col.setAttribute('data-text', (entry.title + ' ' + entry.authors).toLowerCase());
+      col.setAttribute('data-text', (entry.title + ' ' + entry.authors + ' ' + (entry.journal || '') + ' ' + (entry.venue || '')).toLowerCase());
+      col.setAttribute('data-publisher', entry.publisher || '');
       let html = '<div class="publication-card card h-100">';
       html += '<div class="card-body">';
       html += `<h5 class="card-title">${entry.title}</h5>`;
+      html += `<p class="text-sm text-accent2 mb-2"><i class="fa-regular fa-calendar me-1"></i>${entry.year}</p>`;
       // Build citation text
       let citation = `${entry.authors}, “${entry.title},” `;
       if (entry.journal) {
@@ -462,7 +502,7 @@ function initSection(data, containerId, searchId, filterId, countId) {
       html += '<div class="d-flex flex-wrap gap-2">';
       // Code badge with Font Awesome GitHub icon and custom colour
       if (entry.codeUrl) {
-        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code"><i class="fa fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
+        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code"><i class="fa-brands fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
       }
       // Publisher badge with Academicon icon if available
       if (entry.publisher) {
@@ -501,28 +541,54 @@ function initSection(data, containerId, searchId, filterId, countId) {
   }
 
   // Initial render
-  renderCards(data);
+  renderCards(normalizedData);
 
   // Search and filter logic
   function applyFilter() {
     const term = searchInput.value.trim().toLowerCase();
     const year = yearSelect.value;
-    Array.from(container.children).forEach((col) => {
+    const publisher = publisherSelect.value;
+    const cards = Array.from(container.children);
+    cards.sort((a, b) => {
+      if (sortSelect.value === 'title') {
+        return a.querySelector('.card-title').textContent.localeCompare(b.querySelector('.card-title').textContent);
+      }
+      const yearA = Number(a.dataset.year || 0);
+      const yearB = Number(b.dataset.year || 0);
+      return sortSelect.value === 'oldest' ? yearA - yearB : yearB - yearA;
+    });
+    cards.forEach((col) => {
       const matchesText = col.dataset.text.includes(term);
       const matchesYear = year === 'all' || col.dataset.year === year;
-      col.style.display = matchesText && matchesYear ? '' : 'none';
+      const matchesPublisher = publisher === 'all' || col.dataset.publisher === publisher;
+      col.style.display = matchesText && matchesYear && matchesPublisher ? '' : 'none';
+      container.appendChild(col);
     });
+    if (resultsCount) {
+      const visible = cards.filter((c) => c.style.display !== 'none').length;
+      resultsCount.textContent = `Showing ${visible} result${visible === 1 ? '' : 's'}`;
+    }
   }
 
   searchInput.addEventListener('input', applyFilter);
   yearSelect.addEventListener('change', applyFilter);
+  publisherSelect.addEventListener('change', applyFilter);
+  sortSelect.addEventListener('change', applyFilter);
+  clearButton.addEventListener('click', () => {
+    searchInput.value = '';
+    yearSelect.value = 'all';
+    publisherSelect.value = 'all';
+    sortSelect.value = 'latest';
+    applyFilter();
+  });
+  applyFilter();
 }
 
 // Initialise publications once DOM is ready
 function initializePublications() {
-  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count');
-  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count');
-  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count');
+  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
+  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
+  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
 
   // AOS animations
   if (typeof AOS !== 'undefined') {


### PR DESCRIPTION
### Motivation
- Improve discovery and browsing of the publications section by adding publisher filtering, sorting, and result counts.
- Make publications listing dynamic and better sorted by year/date/title for easier navigation.
- Surface newer work and metadata by adding a 2026 journal entry to the data array.
- Add recent profile and LLM/RAG skills to the site content for updated capabilities.

### Description
- Updated `index.html` to add AI/LLM skill items, a descriptive paragraph with a Google Scholar link, and UI controls including publisher selects, sort selects, clear buttons, and per-tab results counts. 
- Modified the publications layout for responsiveness and reduced spacing, and added `id` hooks such as `journal-publisher-filter`, `journal-sort`, `journal-clear-filters`, and `journal-results-count` for each tab. 
- Expanded `js/script.js` by adding a 2026 `journalData` entry and changing `initSection` signature to accept publisher, sort, clear, and results count parameters. 
- Implemented normalization and deterministic sorting of data, populated unique publisher options, added dataset attributes (`data-publisher`, `data-text`) on cards, implemented client-side sorting, publisher filtering, live results count updates, and a clear-filters action. 
- Minor rendering fixes and enhancements include using `fa-brands fa-github` for the code badge, showing year badges, and rendering publisher/venue badges with icon mappings.

### Testing
- No automated tests were added or run for these UI and data changes.