### PR TITLE
Add dynamic publications UI, sorting/filters and News section

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,7 @@
           <li><a href="#experience" class="hover:text-accent">Experience</a></li>
           <li><a href="#skills" class="hover:text-accent">Skills</a></li>
           <li><a href="#works" class="hover:text-accent">Works</a></li>
+          <li><a href="#news" class="hover:text-accent">News</a></li>
           <li><a href="#achievements" class="hover:text-accent">Achievements</a></li>
           <li><a href="#contact" class="hover:text-accent">Contact</a></li>
         </ul>
@@ -255,6 +256,7 @@
         <a href="#experience" class="block py-1 hover:text-accent">Experience</a>
         <a href="#skills" class="block py-1 hover:text-accent">Skills</a>
         <a href="#works" class="block py-1 hover:text-accent">Works</a>
+        <a href="#news" class="block py-1 hover:text-accent">News</a>
         <a href="#achievements" class="block py-1 hover:text-accent">Achievements</a>
         <a href="#contact" class="block py-1 hover:text-accent">Contact</a>
       </div>
@@ -583,7 +585,8 @@
     <!-- Works Section -->
 <section id="works" class="py-20 bg-primaryDark text-gray-100 relative" style="background-image: linear-gradient(rgba(40,63,35,0.85), rgba(40,63,35,0.85)), url('assets/img/publications.JPG'); background-size: cover; background-position: center; background-repeat: no-repeat;" data-aos="fade-up">
       <div class="max-w-6xl mx-auto px-4">
-          <h2 class="text-3xl font-semibold mb-10 text-accent2">Works</h2>
+          <h2 class="text-3xl font-semibold mb-4 text-accent2">Works</h2>
+          <p class="text-sm text-gray-300 mb-6">Publications are arranged by type and sorted by latest year/date for easier browsing. For the most current citation profile, view Google Scholar: <a href="https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en" target="_blank" class="text-accent2 hover:text-accent underline">PV8dJDkAAAAJ</a>.</p>
           <!-- Removed static Top Works section to rely on dynamic publications -->
           <!-- Tabs -->
           <div class="tabs flex flex-col sm:flex-row gap-4 mb-8">
@@ -593,34 +596,85 @@
           </div>
           <!-- Journals -->
           <div id="journal-tab" class="tab-content">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="journal-search" type="text" placeholder="Search journal publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="journal-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="journal-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="journal-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="journal-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="journal-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="journal-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
           <!-- Conferences -->
           <div id="conference-tab" class="tab-content hidden">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="conf-search" type="text" placeholder="Search conference publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="conf-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="conf-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="conf-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="conf-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="conf-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="conference-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
           <!-- Chapters -->
           <div id="chapters-tab" class="tab-content hidden">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="chapters-search" type="text" placeholder="Search book chapters…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="chapters-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="chapters-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="chapters-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="chapters-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="chapters-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="book-chapters" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
+      </div>
+    </section>
+
+    <!-- News Section -->
+    <section id="news" class="py-20 bg-dark text-gray-100 relative" data-aos="fade-up">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
+          <div>
+            <h2 class="text-3xl font-semibold text-accent2">News</h2>
+            <p class="text-sm text-gray-300 mt-2">Major life and career updates in a blog-style timeline. To add a post, append one object to <code>newsData</code> in <code>js/script.js</code>.</p>
+          </div>
+          <span id="news-count" class="text-xs text-gray-400">0 posts</span>
+        </div>
+        <div class="flex flex-col md:flex-row gap-3 mb-6">
+          <input id="news-search" type="text" placeholder="Search updates by title, summary, or tags…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+          <select id="news-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+            <option value="all">All Years</option>
+          </select>
+          <button id="news-clear" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
+        </div>
+        <div id="news-list" class="space-y-4"></div>
       </div>
     </section>
 

--- a/js/script.js
+++ b/js/script.js
@@ -10,6 +10,19 @@
 
 const journalData = [
   {
+    year: 2026,
+    authors: "FJP Montalbo",
+    title:
+      "MHADFormer: A Cost-Efficient Multiscale Hybrid Transformer Mixer Model for Automating Alzheimer’s Disease Diagnosis from MRI Scans",
+    journal: "Applied Soft Computing",
+    volume: "114624",
+    date: "2026",
+    doi: "10.1016/j.asoc.2026.114624",
+    doiUrl: "https://doi.org/10.1016/j.asoc.2026.114624",
+    codeUrl: "https://github.com/francismontalbo/mhadformer",
+    publisher: "Elsevier"
+  },
+  {
     year: 2025,
     authors: "FJP Montalbo",
     title:
@@ -370,6 +383,27 @@ const chapterData = [
   }
 ];
 
+// News posts (easy content management: add newest items here).
+const newsData = [
+  {
+    date: "2026-04-15",
+    title: "Accepted: MHADFormer in Applied Soft Computing",
+    summary: "Our work on MHADFormer for Alzheimer’s diagnosis from MRI scans was accepted and published in Applied Soft Computing (Article 114624).",
+    tags: ["publication", "health-ai", "milestone"],
+    link: "https://doi.org/10.1016/j.asoc.2026.114624",
+    linkLabel: "Read article",
+    pinned: true
+  },
+  {
+    date: "2025-01-01",
+    title: "Released TUMbRAIN code and publication",
+    summary: "Published TUMbRAIN in Neurocomputing and released the accompanying repository for reproducible experiments.",
+    tags: ["publication", "open-source", "medical-imaging"],
+    link: "https://github.com/francismontalbo/tumbrain",
+    linkLabel: "View code"
+  }
+];
+
 // Mapping of publishers to custom badge classes
 const publisherBadgeMap = {
   'Elsevier': 'badge-elsevier',
@@ -411,24 +445,54 @@ const closedAccessIconClass = 'ai ai-closed-access';
  * @param {string} filterId - id of year filter select
  * @param {string} countId - id of span to show total count (optional)
  */
-function initSection(data, containerId, searchId, filterId, countId) {
+function initSection(data, containerId, searchId, filterId, countId, publisherFilterId, sortId, clearId, resultsCountId) {
+  const parseDate = (entry) => {
+    const parsed = entry.date ? Date.parse(entry.date) : Number.NaN;
+    return Number.isFinite(parsed) ? parsed : Number(entry.year || 0);
+  };
+  const sortData = (items, sortMode = 'latest') => {
+    const sorted = [...items];
+    sorted.sort((a, b) => {
+      if (sortMode === 'title') {
+        return (a.title || '').localeCompare(b.title || '');
+      }
+      const yearDiff = Number(a.year || 0) - Number(b.year || 0);
+      if (yearDiff !== 0) return sortMode === 'oldest' ? yearDiff : -yearDiff;
+      const dateDiff = parseDate(a) - parseDate(b);
+      if (dateDiff !== 0) return sortMode === 'oldest' ? dateDiff : -dateDiff;
+      return (a.title || '').localeCompare(b.title || '');
+    });
+    return sorted;
+  };
+  const normalizedData = sortData(data, 'latest');
   const container = document.getElementById(containerId);
   const searchInput = document.getElementById(searchId);
   const yearSelect = document.getElementById(filterId);
+  const publisherSelect = document.getElementById(publisherFilterId);
+  const sortSelect = document.getElementById(sortId);
+  const clearButton = document.getElementById(clearId);
+  const resultsCount = document.getElementById(resultsCountId);
   const countSpan = document.getElementById(countId);
 
   // Populate year dropdown with unique years
-  const years = Array.from(new Set(data.map((d) => d.year))).sort((a, b) => b - a);
+  const years = Array.from(new Set(normalizedData.map((d) => d.year))).sort((a, b) => b - a);
   years.forEach((y) => {
     const opt = document.createElement('option');
     opt.value = y;
     opt.textContent = y;
     yearSelect.appendChild(opt);
   });
+  const publishers = Array.from(new Set(normalizedData.map((d) => d.publisher).filter(Boolean))).sort();
+  publishers.forEach((publisher) => {
+    const opt = document.createElement('option');
+    opt.value = publisher;
+    opt.textContent = publisher;
+    publisherSelect.appendChild(opt);
+  });
 
   // Show total count if applicable
   if (countSpan) {
-    countSpan.textContent = data.length;
+    countSpan.textContent = normalizedData.length;
   }
 
   // Render publication cards
@@ -437,11 +501,10 @@ function initSection(data, containerId, searchId, filterId, countId) {
     items.forEach((entry) => {
       const col = document.createElement('div');
       col.className = 'col-md-6';
-      col.setAttribute('data-year', entry.year);
-      col.setAttribute('data-text', (entry.title + ' ' + entry.authors).toLowerCase());
       let html = '<div class="publication-card card h-100">';
       html += '<div class="card-body">';
       html += `<h5 class="card-title">${entry.title}</h5>`;
+      html += `<p class="text-sm text-accent2 mb-2"><i class="fa-regular fa-calendar me-1"></i>${entry.year}</p>`;
       // Build citation text
       let citation = `${entry.authors}, “${entry.title},” `;
       if (entry.journal) {
@@ -459,10 +522,10 @@ function initSection(data, containerId, searchId, filterId, countId) {
       citation += '.';
       html += `<p class="card-text">${citation}</p>`;
       // Build badges
-      html += '<div class="d-flex flex-wrap gap-2">';
+      html += '<div class="d-flex flex-wrap gap-2 mt-3 pt-1">';
       // Code badge with Font Awesome GitHub icon and custom colour
       if (entry.codeUrl) {
-        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code"><i class="fa fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
+        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code" aria-label="Code repository"><i class="fab fa-github fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
       }
       // Publisher badge with Academicon icon if available
       if (entry.publisher) {
@@ -500,29 +563,44 @@ function initSection(data, containerId, searchId, filterId, countId) {
     });
   }
 
-  // Initial render
-  renderCards(data);
-
   // Search and filter logic
   function applyFilter() {
     const term = searchInput.value.trim().toLowerCase();
     const year = yearSelect.value;
-    Array.from(container.children).forEach((col) => {
-      const matchesText = col.dataset.text.includes(term);
-      const matchesYear = year === 'all' || col.dataset.year === year;
-      col.style.display = matchesText && matchesYear ? '' : 'none';
+    const publisher = publisherSelect.value;
+    const sortMode = sortSelect.value;
+    const filtered = normalizedData.filter((entry) => {
+      const haystack = `${entry.title || ''} ${entry.authors || ''} ${entry.journal || ''} ${entry.venue || ''} ${entry.publisher || ''}`.toLowerCase();
+      const matchesText = haystack.includes(term);
+      const matchesYear = year === 'all' || String(entry.year) === year;
+      const matchesPublisher = publisher === 'all' || (entry.publisher || '') === publisher;
+      return matchesText && matchesYear && matchesPublisher;
     });
+    renderCards(sortData(filtered, sortMode));
+    if (resultsCount) {
+      resultsCount.textContent = `Showing ${filtered.length} result${filtered.length === 1 ? '' : 's'}`;
+    }
   }
 
   searchInput.addEventListener('input', applyFilter);
   yearSelect.addEventListener('change', applyFilter);
+  publisherSelect.addEventListener('change', applyFilter);
+  sortSelect.addEventListener('change', applyFilter);
+  clearButton.addEventListener('click', () => {
+    searchInput.value = '';
+    yearSelect.value = 'all';
+    publisherSelect.value = 'all';
+    sortSelect.value = 'latest';
+    applyFilter();
+  });
+  applyFilter();
 }
 
 // Initialise publications once DOM is ready
 function initializePublications() {
-  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count');
-  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count');
-  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count');
+  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
+  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
+  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
 
   // AOS animations
   if (typeof AOS !== 'undefined') {
@@ -551,9 +629,78 @@ function initializePublications() {
   }
 }
 
+function initializeNews() {
+  const list = document.getElementById('news-list');
+  const search = document.getElementById('news-search');
+  const yearFilter = document.getElementById('news-year-filter');
+  const clearBtn = document.getElementById('news-clear');
+  const count = document.getElementById('news-count');
+
+  if (!list || !search || !yearFilter || !clearBtn || !count) return;
+
+  const sorted = [...newsData].sort((a, b) => {
+    if (Boolean(b.pinned) !== Boolean(a.pinned)) return b.pinned ? 1 : -1;
+    return new Date(b.date) - new Date(a.date);
+  });
+
+  const years = Array.from(new Set(sorted.map((n) => new Date(n.date).getFullYear()))).sort((a, b) => b - a);
+  years.forEach((year) => {
+    const opt = document.createElement('option');
+    opt.value = String(year);
+    opt.textContent = String(year);
+    yearFilter.appendChild(opt);
+  });
+
+  function render(items) {
+    list.innerHTML = '';
+    items.forEach((item) => {
+      const tags = (item.tags || []).map((tag) => `<span class="badge badge-default">#${tag}</span>`).join(' ');
+      const article = document.createElement('article');
+      article.className = 'publication-card';
+      article.innerHTML = `
+        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+          <div>
+            <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
+            <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
+            <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
+          </div>
+          ${item.link ? `<a href="${item.link}" target="_blank" class="badge badge-code whitespace-nowrap mt-1">${item.linkLabel || 'Read more'}</a>` : ''}
+        </div>`;
+      list.appendChild(article);
+    });
+    count.textContent = `${items.length} post${items.length === 1 ? '' : 's'}`;
+  }
+
+  function apply() {
+    const term = search.value.trim().toLowerCase();
+    const selectedYear = yearFilter.value;
+    const filtered = sorted.filter((item) => {
+      const year = String(new Date(item.date).getFullYear());
+      const haystack = `${item.title} ${item.summary} ${(item.tags || []).join(' ')}`.toLowerCase();
+      return (selectedYear === 'all' || selectedYear === year) && haystack.includes(term);
+    });
+    render(filtered);
+  }
+
+  search.addEventListener('input', apply);
+  yearFilter.addEventListener('change', apply);
+  clearBtn.addEventListener('click', () => {
+    search.value = '';
+    yearFilter.value = 'all';
+    apply();
+  });
+
+  apply();
+}
+
 // Run initialisation immediately or defer to DOMContentLoaded
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializePublications);
+  document.addEventListener('DOMContentLoaded', () => {
+    initializePublications();
+    initializeNews();
+  });
 } else {
   initializePublications();
+  initializeNews();
 }


### PR DESCRIPTION
### Motivation
- Improve the Works/publications area to be more discoverable and manageable with search, year and publisher filters and sorting options. 
- Surface recent life and career updates via a lightweight `news` section for blog-style timeline posts. 
- Add a few recent publication entries and metadata (publisher, DOI, code links) so the site content is up-to-date. 

### Description
- Updated navigation to include a `#news` link and added a new `#news` section with search, year filter, clear button and post count, populated by the new `newsData` array in `js/script.js`. 
- Enhanced the Works section UI and behavior by adding publisher filters, sorting (`latest`, `oldest`, `title`), clear buttons, and results counts for journals, conferences and chapters, and shortened the Works header with a link to Google Scholar. 
- Refactored `initSection` in `js/script.js` to accept publisher, sort and clear controls and to normalize/sort data before rendering; rendering now includes year display, improved badges (publisher, code, PubMed, access) and minor accessibility attributes on links. 
- Added new publication entries (including `MHADFormer` and others) to `journalData`, added `newsData` sample posts, and extended publisher/icon maps for badge rendering; initialized both publications and news on `DOMContentLoaded`. 

### Testing
- No automated tests were executed as part of this change.