### PR TITLE
Add dynamic publications UI, News feed, and profile chatbot with improved filters and badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,15 @@
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
+        text-decoration: none !important;
+      }
+      .badge-code, .badge-code i, .publication-card a.badge-code {
+        color: #0B0F08 !important;
+      }
+      .badge-code:hover {
+        background-color: #B7C970;
+        color: #0B0F08 !important;
+        text-decoration: none !important;
       }
 
       /* Additional custom classes for card and timeline styling */
@@ -244,6 +253,8 @@
           <li><a href="#experience" class="hover:text-accent">Experience</a></li>
           <li><a href="#skills" class="hover:text-accent">Skills</a></li>
           <li><a href="#works" class="hover:text-accent">Works</a></li>
+          <li><a href="#news" class="hover:text-accent">News</a></li>
+          <li><a href="#chatbot" class="hover:text-accent">Chatbot</a></li>
           <li><a href="#achievements" class="hover:text-accent">Achievements</a></li>
           <li><a href="#contact" class="hover:text-accent">Contact</a></li>
         </ul>
@@ -255,6 +266,8 @@
         <a href="#experience" class="block py-1 hover:text-accent">Experience</a>
         <a href="#skills" class="block py-1 hover:text-accent">Skills</a>
         <a href="#works" class="block py-1 hover:text-accent">Works</a>
+        <a href="#news" class="block py-1 hover:text-accent">News</a>
+        <a href="#chatbot" class="block py-1 hover:text-accent">Chatbot</a>
         <a href="#achievements" class="block py-1 hover:text-accent">Achievements</a>
         <a href="#contact" class="block py-1 hover:text-accent">Contact</a>
       </div>
@@ -583,44 +596,139 @@
     <!-- Works Section -->
 <section id="works" class="py-20 bg-primaryDark text-gray-100 relative" style="background-image: linear-gradient(rgba(40,63,35,0.85), rgba(40,63,35,0.85)), url('assets/img/publications.JPG'); background-size: cover; background-position: center; background-repeat: no-repeat;" data-aos="fade-up">
       <div class="max-w-6xl mx-auto px-4">
-          <h2 class="text-3xl font-semibold mb-10 text-accent2">Works</h2>
+          <h2 class="text-3xl font-semibold mb-4 text-accent2">Works</h2>
+          <p class="text-sm text-gray-300 mb-6">Publications are arranged by type and sorted by latest year/date for easier browsing. For the most updated and more accurate research profile (including citation metrics), view Google Scholar: <a href="https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en" target="_blank" class="text-accent2 hover:text-accent underline">PV8dJDkAAAAJ</a> and Scopus: <a href="https://www.scopus.com/authid/detail.uri?authorId=57221928564" target="_blank" class="text-accent2 hover:text-accent underline">Author ID 57221928564</a>.</p>
           <!-- Removed static Top Works section to rely on dynamic publications -->
           <!-- Tabs -->
           <div class="tabs flex flex-col sm:flex-row gap-4 mb-8">
+            <button class="tab px-4 py-2 rounded-md text-sm font-medium bg-primary text-gray-100 hover:bg-tertiary focus:outline-none" data-target="all-tab">All</button>
             <button class="tab px-4 py-2 rounded-md text-sm font-medium bg-primary text-gray-100 hover:bg-tertiary focus:outline-none" data-target="journal-tab">Journals</button>
             <button class="tab px-4 py-2 rounded-md text-sm font-medium bg-primary text-gray-100 hover:bg-tertiary focus:outline-none" data-target="conference-tab">Conferences</button>
             <button class="tab px-4 py-2 rounded-md text-sm font-medium bg-primary text-gray-100 hover:bg-tertiary focus:outline-none" data-target="chapters-tab">Chapters</button>
           </div>
+          <!-- All -->
+          <div id="all-tab" class="tab-content">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
+              <input id="all-search" type="text" placeholder="Search all publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+              <select id="all-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Years</option>
+              </select>
+              <select id="all-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="all-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="all-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
+            </div>
+            <p id="all-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
+            <div id="all-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
+          </div>
           <!-- Journals -->
-          <div id="journal-tab" class="tab-content">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+          <div id="journal-tab" class="tab-content hidden">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="journal-search" type="text" placeholder="Search journal publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="journal-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="journal-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="journal-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="journal-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="journal-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="journal-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
           <!-- Conferences -->
           <div id="conference-tab" class="tab-content hidden">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="conf-search" type="text" placeholder="Search conference publications…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="conf-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="conf-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="conf-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="conf-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="conf-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="conference-publications" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
           <!-- Chapters -->
           <div id="chapters-tab" class="tab-content hidden">
-            <div class="flex flex-col sm:flex-row gap-4 mb-4">
+            <div class="flex flex-col lg:flex-row gap-3 mb-4">
               <input id="chapters-search" type="text" placeholder="Search book chapters…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
               <select id="chapters-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
                 <option value="all">All Years</option>
               </select>
+              <select id="chapters-publisher-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="all">All Publishers</option>
+              </select>
+              <select id="chapters-sort" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+                <option value="latest">Sort: Latest</option>
+                <option value="oldest">Sort: Oldest</option>
+                <option value="title">Sort: Title A–Z</option>
+              </select>
+              <button id="chapters-clear-filters" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
             </div>
+            <p id="chapters-results-count" class="text-xs text-gray-300 mb-4">Showing 0 results</p>
             <div id="book-chapters" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
           </div>
+      </div>
+    </section>
+
+    <!-- News Section -->
+    <section id="news" class="py-20 bg-dark text-gray-100 relative" data-aos="fade-up">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
+          <div>
+            <h2 class="text-3xl font-semibold text-accent2">News</h2>
+          <p class="text-sm text-gray-300 mt-2">Major life and career updates in a blog-style timeline—highlighting impact, recognition, and real-world contributions.</p>
+          </div>
+          <span id="news-count" class="text-xs text-gray-400">0 posts</span>
+        </div>
+        <div class="flex flex-col md:flex-row gap-3 mb-6">
+          <input id="news-search" type="text" placeholder="Search updates by title, summary, or tags…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+          <select id="news-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
+            <option value="all">All Years</option>
+          </select>
+          <button id="news-clear" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
+        </div>
+        <div id="news-list" class="space-y-4"></div>
+      </div>
+    </section>
+
+    <!-- Personal Chatbot Section -->
+    <section id="chatbot" class="py-20 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
+      <div class="max-w-4xl mx-auto px-4">
+        <h2 class="text-3xl font-semibold text-accent2 mb-3">Ask Francis AI</h2>
+        <p class="text-sm text-gray-300 mb-6">A profile-grounded assistant that works instantly and answers only about Dr. Francis Jesmar P. Montalbo (research, work, skills, and achievements).</p>
+        <div class="publication-card">
+          <div id="chatbot-messages" class="rounded-md bg-primaryDark border border-primary p-4 text-sm text-gray-100 min-h-[260px] max-h-[420px] overflow-y-auto space-y-3 mb-4">
+            <div class="max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100">Hi! I’m Francis AI. Ask me about Francis’ publications, awards, affiliations, and expertise.</div>
+          </div>
+          <div class="flex flex-wrap gap-2 mb-4">
+            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
+            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
+            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="Show recent publications by Francis.">Recent Works</button>
+          </div>
+          <div class="flex gap-3">
+            <input id="chatbot-input" type="text" placeholder="Type your question..." class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+            <button id="chatbot-send" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Ask</button>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -732,16 +840,5 @@
     <!-- Custom Script for publications -->
     <!-- Load custom publications script with defer to ensure DOM is parsed before execution -->
     <script src="js/script.js" defer></script>
-    <!-- Inline publications script -->
-    <script>
-      /* arrays and helper functions from scripts.js here */
-      …
-      // If the DOM is still loading, defer initialisation to DOMContentLoaded; otherwise run immediately.
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initializePublications);
-      } else {
-        initializePublications();
-      }
-    </script>
   </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -10,6 +10,19 @@
 
 const journalData = [
   {
+    year: 2026,
+    authors: "FJP Montalbo",
+    title:
+      "MHADFormer: A Cost-Efficient Multiscale Hybrid Transformer Mixer Model for Automating Alzheimer’s Disease Diagnosis from MRI Scans",
+    journal: "Applied Soft Computing",
+    volume: "114624",
+    date: "2026",
+    doi: "10.1016/j.asoc.2026.114624",
+    doiUrl: "https://doi.org/10.1016/j.asoc.2026.114624",
+    codeUrl: "https://github.com/francismontalbo/mhadformer",
+    publisher: "Elsevier"
+  },
+  {
     year: 2025,
     authors: "FJP Montalbo",
     title:
@@ -370,6 +383,37 @@ const chapterData = [
   }
 ];
 
+// News posts (easy content management: add newest items here).
+const newsData = [
+  {
+    date: "2026-05-05",
+    title: "National Spotlight: Recognized in OneNews Stanford Scientists Feature",
+    summary: "I was highlighted in OneNews’ coverage of the Stanford global scientist rankings—reinforcing my standing as an internationally recognized Filipino researcher contributing high-impact AI and biomedical signal processing work.",
+    tags: ["media-feature", "stanford-top-2%", "research-impact"],
+    link: "https://www.onenews.ph/articles/phl-has-fewest-scientists-in-asean-stanford-list",
+    linkLabel: "Read feature",
+    pinned: true
+  },
+  {
+    date: "2023-10-22",
+    title: "ICBSP 2023: Selected as One of the Best Presenters",
+    summary: "At ICBSP 2023, my presentation was selected among the conference’s best presenters—reflecting the clarity, novelty, and applied value of my research in biomedical imaging and AI.",
+    tags: ["best-presenter", "international-conference", "ai-research"],
+    link: "https://www.icbsp.org/icbsp2023.html",
+    linkLabel: "Conference page",
+    pinned: true
+  }
+];
+
+const profileContext = `
+Name: Dr. Francis Jesmar P. Montalbo
+Roles: Associate Professor, Research Scientist, AI & Deep Learning Specialist, Software Engineer
+Affiliation: Batangas State University
+Research: medical imaging AI, deep learning, biomedical signal processing, computer vision
+Selected Achievements: OneNews Stanford scientists feature; ICBSP 2023 best presenter
+Use only this profile context plus on-page publications/news data. If asked outside scope, politely refuse.
+`;
+
 // Mapping of publishers to custom badge classes
 const publisherBadgeMap = {
   'Elsevier': 'badge-elsevier',
@@ -411,24 +455,54 @@ const closedAccessIconClass = 'ai ai-closed-access';
  * @param {string} filterId - id of year filter select
  * @param {string} countId - id of span to show total count (optional)
  */
-function initSection(data, containerId, searchId, filterId, countId) {
+function initSection(data, containerId, searchId, filterId, countId, publisherFilterId, sortId, clearId, resultsCountId) {
+  const parseDate = (entry) => {
+    const parsed = entry.date ? Date.parse(entry.date) : Number.NaN;
+    return Number.isFinite(parsed) ? parsed : Number(entry.year || 0);
+  };
+  const sortData = (items, sortMode = 'latest') => {
+    const sorted = [...items];
+    sorted.sort((a, b) => {
+      if (sortMode === 'title') {
+        return (a.title || '').localeCompare(b.title || '');
+      }
+      const yearDiff = Number(a.year || 0) - Number(b.year || 0);
+      if (yearDiff !== 0) return sortMode === 'oldest' ? yearDiff : -yearDiff;
+      const dateDiff = parseDate(a) - parseDate(b);
+      if (dateDiff !== 0) return sortMode === 'oldest' ? dateDiff : -dateDiff;
+      return (a.title || '').localeCompare(b.title || '');
+    });
+    return sorted;
+  };
+  const normalizedData = sortData(data, 'latest');
   const container = document.getElementById(containerId);
   const searchInput = document.getElementById(searchId);
   const yearSelect = document.getElementById(filterId);
+  const publisherSelect = document.getElementById(publisherFilterId);
+  const sortSelect = document.getElementById(sortId);
+  const clearButton = document.getElementById(clearId);
+  const resultsCount = document.getElementById(resultsCountId);
   const countSpan = document.getElementById(countId);
 
   // Populate year dropdown with unique years
-  const years = Array.from(new Set(data.map((d) => d.year))).sort((a, b) => b - a);
+  const years = Array.from(new Set(normalizedData.map((d) => d.year))).sort((a, b) => b - a);
   years.forEach((y) => {
     const opt = document.createElement('option');
     opt.value = y;
     opt.textContent = y;
     yearSelect.appendChild(opt);
   });
+  const publishers = Array.from(new Set(normalizedData.map((d) => d.publisher).filter(Boolean))).sort();
+  publishers.forEach((publisher) => {
+    const opt = document.createElement('option');
+    opt.value = publisher;
+    opt.textContent = publisher;
+    publisherSelect.appendChild(opt);
+  });
 
   // Show total count if applicable
   if (countSpan) {
-    countSpan.textContent = data.length;
+    countSpan.textContent = normalizedData.length;
   }
 
   // Render publication cards
@@ -437,11 +511,10 @@ function initSection(data, containerId, searchId, filterId, countId) {
     items.forEach((entry) => {
       const col = document.createElement('div');
       col.className = 'col-md-6';
-      col.setAttribute('data-year', entry.year);
-      col.setAttribute('data-text', (entry.title + ' ' + entry.authors).toLowerCase());
       let html = '<div class="publication-card card h-100">';
       html += '<div class="card-body">';
       html += `<h5 class="card-title">${entry.title}</h5>`;
+      html += `<p class="text-sm text-accent2 mb-2"><i class="fa-regular fa-calendar me-1"></i>${entry.year}</p>`;
       // Build citation text
       let citation = `${entry.authors}, “${entry.title},” `;
       if (entry.journal) {
@@ -459,10 +532,10 @@ function initSection(data, containerId, searchId, filterId, countId) {
       citation += '.';
       html += `<p class="card-text">${citation}</p>`;
       // Build badges
-      html += '<div class="d-flex flex-wrap gap-2">';
+      html += '<div class="d-flex flex-wrap gap-2 mt-3 pt-1">';
       // Code badge with Font Awesome GitHub icon and custom colour
       if (entry.codeUrl) {
-        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code"><i class="fa fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
+        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code" aria-label="Code repository"><i class="fab fa-github fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
       }
       // Publisher badge with Academicon icon if available
       if (entry.publisher) {
@@ -500,29 +573,50 @@ function initSection(data, containerId, searchId, filterId, countId) {
     });
   }
 
-  // Initial render
-  renderCards(data);
-
   // Search and filter logic
   function applyFilter() {
     const term = searchInput.value.trim().toLowerCase();
     const year = yearSelect.value;
-    Array.from(container.children).forEach((col) => {
-      const matchesText = col.dataset.text.includes(term);
-      const matchesYear = year === 'all' || col.dataset.year === year;
-      col.style.display = matchesText && matchesYear ? '' : 'none';
+    const publisher = publisherSelect.value;
+    const sortMode = sortSelect.value;
+    const filtered = normalizedData.filter((entry) => {
+      const haystack = `${entry.title || ''} ${entry.authors || ''} ${entry.journal || ''} ${entry.venue || ''} ${entry.publisher || ''}`.toLowerCase();
+      const matchesText = haystack.includes(term);
+      const matchesYear = year === 'all' || String(entry.year) === year;
+      const matchesPublisher = publisher === 'all' || (entry.publisher || '') === publisher;
+      return matchesText && matchesYear && matchesPublisher;
     });
+    renderCards(sortData(filtered, sortMode));
+    if (resultsCount) {
+      resultsCount.textContent = `Showing ${filtered.length} result${filtered.length === 1 ? '' : 's'}`;
+    }
   }
 
   searchInput.addEventListener('input', applyFilter);
   yearSelect.addEventListener('change', applyFilter);
+  publisherSelect.addEventListener('change', applyFilter);
+  sortSelect.addEventListener('change', applyFilter);
+  clearButton.addEventListener('click', () => {
+    searchInput.value = '';
+    yearSelect.value = 'all';
+    publisherSelect.value = 'all';
+    sortSelect.value = 'latest';
+    applyFilter();
+  });
+  applyFilter();
 }
 
 // Initialise publications once DOM is ready
 function initializePublications() {
-  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count');
-  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count');
-  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count');
+  const allData = [
+    ...journalData.map((item) => ({ ...item })),
+    ...conferenceData.map((item) => ({ ...item })),
+    ...chapterData.map((item) => ({ ...item, journal: item.book }))
+  ];
+  initSection(allData, 'all-publications', 'all-search', 'all-year-filter', 'all-count', 'all-publisher-filter', 'all-sort', 'all-clear-filters', 'all-results-count');
+  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
+  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
+  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
 
   // AOS animations
   if (typeof AOS !== 'undefined') {
@@ -551,9 +645,169 @@ function initializePublications() {
   }
 }
 
+function initializeNews() {
+  const list = document.getElementById('news-list');
+  const search = document.getElementById('news-search');
+  const yearFilter = document.getElementById('news-year-filter');
+  const clearBtn = document.getElementById('news-clear');
+  const count = document.getElementById('news-count');
+
+  if (!list || !search || !yearFilter || !clearBtn || !count) return;
+
+  const sorted = [...newsData].sort((a, b) => {
+    if (Boolean(b.pinned) !== Boolean(a.pinned)) return b.pinned ? 1 : -1;
+    return new Date(b.date) - new Date(a.date);
+  });
+
+  const years = Array.from(new Set(sorted.map((n) => new Date(n.date).getFullYear()))).sort((a, b) => b - a);
+  years.forEach((year) => {
+    const opt = document.createElement('option');
+    opt.value = String(year);
+    opt.textContent = String(year);
+    yearFilter.appendChild(opt);
+  });
+
+  function render(items) {
+    list.innerHTML = '';
+    items.forEach((item) => {
+      const tags = (item.tags || []).map((tag) => `<span class="badge badge-default">#${tag}</span>`).join(' ');
+      const article = document.createElement('article');
+      article.className = 'publication-card';
+      article.innerHTML = `
+        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+          <div>
+            <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
+            <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
+            <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
+          </div>
+          ${item.link ? `<a href="${item.link}" target="_blank" class="badge badge-code whitespace-nowrap mt-1">${item.linkLabel || 'Read more'}</a>` : ''}
+        </div>`;
+      list.appendChild(article);
+    });
+    count.textContent = `${items.length} post${items.length === 1 ? '' : 's'}`;
+  }
+
+  function apply() {
+    const term = search.value.trim().toLowerCase();
+    const selectedYear = yearFilter.value;
+    const filtered = sorted.filter((item) => {
+      const year = String(new Date(item.date).getFullYear());
+      const haystack = `${item.title} ${item.summary} ${(item.tags || []).join(' ')}`.toLowerCase();
+      return (selectedYear === 'all' || selectedYear === year) && haystack.includes(term);
+    });
+    render(filtered);
+  }
+
+  search.addEventListener('input', apply);
+  yearFilter.addEventListener('change', apply);
+  clearBtn.addEventListener('click', () => {
+    search.value = '';
+    yearFilter.value = 'all';
+    apply();
+  });
+
+  apply();
+}
+
+function initializeChatbot() {
+  const messages = document.getElementById('chatbot-messages');
+  const input = document.getElementById('chatbot-input');
+  const send = document.getElementById('chatbot-send');
+  const chips = document.querySelectorAll('.chatbot-chip');
+  if (!messages || !input || !send) return;
+
+  const allWorks = [
+    ...journalData.map((w) => ({ ...w, type: 'Journal' })),
+    ...conferenceData.map((w) => ({ ...w, type: 'Conference' })),
+    ...chapterData.map((w) => ({ ...w, type: 'Chapter' }))
+  ];
+
+  function addBubble(text, role = 'assistant') {
+    const bubble = document.createElement('div');
+    bubble.className = role === 'user'
+      ? 'max-w-[85%] ml-auto rounded-lg px-3 py-2 bg-accent2 text-dark'
+      : 'max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100';
+    bubble.textContent = text;
+    messages.appendChild(bubble);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  function fallbackAnswer(question) {
+    const q = question.toLowerCase();
+    if (!q.includes('francis') && /(who are you|weather|politics|stock|bitcoin|movie|recipe)/.test(q)) {
+      return 'I can only answer questions specifically about Francis Jesmar P. Montalbo and his profile/work.';
+    }
+    if (q.includes('who is') || q.includes('bio') || q.includes('introduce')) {
+      return 'Dr. Francis Jesmar P. Montalbo is an Associate Professor, Research Scientist, AI & Deep Learning Specialist, and Software Engineer affiliated with Batangas State University.';
+    }
+    if (q.includes('research') || q.includes('area') || q.includes('expert')) {
+      return 'Francis focuses on medical imaging AI, deep learning, biomedical signal processing, and computer vision, with applications in diagnostics and healthcare.';
+    }
+    if (q.includes('recognition') || q.includes('award') || q.includes('best presenter') || q.includes('stanford')) {
+      return 'Notable recognitions include being featured in OneNews for Stanford scientist rankings and being selected as one of the best presenters at ICBSP 2023.';
+    }
+    if (q.includes('recent') || q.includes('publication') || q.includes('paper')) {
+      const latest = [...journalData].sort((a, b) => Number(b.year) - Number(a.year)).slice(0, 3)
+        .map((p) => `• ${p.year}: ${p.title}`).join('\n');
+      return `Here are recent works:\n${latest}`;
+    }
+    if (q.includes('conference') || q.includes('presenter')) {
+      const conf = conferenceData.slice(0, 3).map((c) => `• ${c.year}: ${c.title}`).join('\n');
+      return `Selected conference works:\n${conf}`;
+    }
+    if (q.includes('news') || q.includes('feature') || q.includes('recognition')) {
+      const highlights = newsData.map((n) => `• ${n.date}: ${n.title}`).join('\n');
+      return `Recent highlights:\n${highlights}`;
+    }
+    const matched = allWorks.filter((item) => {
+      const blob = `${item.title} ${item.authors || ''} ${item.journal || ''} ${item.venue || ''}`.toLowerCase();
+      return q.split(/\s+/).some((t) => t.length > 4 && blob.includes(t));
+    }).slice(0, 3);
+    if (matched.length) {
+      return `I found these related works:\n${matched.map((m) => `• [${m.type}] ${m.year}: ${m.title}`).join('\n')}`;
+    }
+    return 'I can help with Francis’ profile, publications, recognitions, affiliations, and research expertise. Please ask within those topics.';
+  }
+
+  async function ask() {
+    const question = input.value.trim();
+    if (!question) return;
+    addBubble(question, 'user');
+    input.value = '';
+    addBubble('Thinking…');
+    const thinkingBubble = messages.lastElementChild;
+    send.disabled = true;
+    try {
+      thinkingBubble.textContent = fallbackAnswer(question);
+    } catch (err) {
+      thinkingBubble.textContent = `Unable to answer right now: ${err.message}`;
+    } finally {
+      send.disabled = false;
+    }
+  }
+
+  send.addEventListener('click', ask);
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') ask();
+  });
+  chips.forEach((chip) => {
+    chip.addEventListener('click', () => {
+      input.value = chip.dataset.question || '';
+      ask();
+    });
+  });
+}
+
 // Run initialisation immediately or defer to DOMContentLoaded
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializePublications);
+  document.addEventListener('DOMContentLoaded', () => {
+    initializePublications();
+    initializeNews();
+    initializeChatbot();
+  });
 } else {
   initializePublications();
+  initializeNews();
+  initializeChatbot();
 }


### PR DESCRIPTION
### Motivation
- Improve the Publications area to support searching, year/publisher filtering, sorting, and an aggregated "All" view for easier browsing.  
- Surface timely career updates via a new News section that can be managed from a JS data array.  
- Provide a lightweight, profile‑bounded assistant so visitors can ask questions about the owner’s profile, works, and recognitions directly on the page.

### Description
- Updated markup and styles in `index.html` to add `News` and `Chatbot` sections, add navbar links, tweak badge styling for `.badge-code`, and adjust the Works header and tabs.  
- Reworked the publications frontend in `js/script.js` by extending `initSection` to support publisher filters, sorting, clear buttons, and results counts, and by creating an aggregated `allData` view registered to the new "All" tab.  
- Added `newsData` and `profileContext` arrays and implemented `initializeNews()` to render, filter, and count news posts, plus `initializeChatbot()` which provides an on‑page, profile‑grounded fallback Q/A helper (no external API calls).  
- Minor data updates, including a new journal entry and improvements to card rendering (date display, badges, accessible code link markup), and DOM initialization to call the new initializers on load.