### PR TITLE
Use live LLM flow for chatbot and add on-demand AI news summaries

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -668,23 +668,59 @@ function initializeNews() {
     yearFilter.appendChild(opt);
   });
 
+  async function generateNewsSummary(item, container) {
+    if (!item.link) return;
+    container.textContent = 'Generating expanded summary…';
+    try {
+      const extracted = await fetch(`https://r.jina.ai/http://${item.link.replace(/^https?:\/\//, '')}`);
+      if (!extracted.ok) throw new Error('Cannot fetch article content');
+      const articleText = (await extracted.text()).slice(0, 12000);
+      const prompt = `You summarize news about Dr. Francis Jesmar P. Montalbo.
+Create a concise expanded summary (max 4 bullet points) based only on the source text.
+Tone: professional and strongly positive, emphasizing Francis's impact and excellence without inventing facts.
+Source text:
+${articleText}`;
+      const llm = await fetch(`https://text.pollinations.ai/${encodeURIComponent(prompt)}`);
+      if (!llm.ok) throw new Error('Summary model unavailable');
+      const summary = (await llm.text()).trim();
+      container.textContent = summary || 'No summary generated.';
+    } catch (error) {
+      container.textContent = 'Unable to generate expanded summary right now. Please open the source link directly.';
+    }
+  }
+
   function render(items) {
     list.innerHTML = '';
-    items.forEach((item) => {
+    items.forEach((item, index) => {
       const tags = (item.tags || []).map((tag) => `<span class="badge badge-default">#${tag}</span>`).join(' ');
       const article = document.createElement('article');
+      const summaryId = `news-expanded-${index}-${item.date}`.replace(/[^a-zA-Z0-9-_]/g, '');
       article.className = 'publication-card';
       article.innerHTML = `
         <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
-          <div>
+          <div class="w-full">
             <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
             <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
             <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            <details class="mt-3">
+              <summary class="cursor-pointer text-sm text-accent">Expand: AI summary of linked article</summary>
+              <p id="${summaryId}" class="text-sm text-gray-300 mt-2">Click "Generate" to load an expanded summary.</p>
+              ${item.link ? `<button data-summary-target="${summaryId}" class="mt-2 px-3 py-1 rounded-md bg-primary text-gray-100 border border-primary hover:bg-tertiary text-xs">Generate</button>` : ''}
+            </details>
             <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
           </div>
           ${item.link ? `<a href="${item.link}" target="_blank" class="badge badge-code whitespace-nowrap mt-1">${item.linkLabel || 'Read more'}</a>` : ''}
         </div>`;
       list.appendChild(article);
+      const button = article.querySelector('button[data-summary-target]');
+      if (button) {
+        button.addEventListener('click', async () => {
+          const target = article.querySelector(`#${button.dataset.summaryTarget}`);
+          button.disabled = true;
+          await generateNewsSummary(item, target);
+          button.disabled = false;
+        });
+      }
     });
     count.textContent = `${items.length} post${items.length === 1 ? '' : 's'}`;
   }
@@ -734,42 +770,7 @@ function initializeChatbot() {
     messages.scrollTop = messages.scrollHeight;
   }
 
-  function fallbackAnswer(question) {
-    const q = question.toLowerCase();
-    if (!q.includes('francis') && /(who are you|weather|politics|stock|bitcoin|movie|recipe)/.test(q)) {
-      return 'I can only answer questions specifically about Francis Jesmar P. Montalbo and his profile/work.';
-    }
-    if (q.includes('who is') || q.includes('bio') || q.includes('introduce')) {
-      return 'Dr. Francis Jesmar P. Montalbo is an Associate Professor, Research Scientist, AI & Deep Learning Specialist, and Software Engineer affiliated with Batangas State University.';
-    }
-    if (q.includes('research') || q.includes('area') || q.includes('expert')) {
-      return 'Francis focuses on medical imaging AI, deep learning, biomedical signal processing, and computer vision, with applications in diagnostics and healthcare.';
-    }
-    if (q.includes('recognition') || q.includes('award') || q.includes('best presenter') || q.includes('stanford')) {
-      return 'Notable recognitions include being featured in OneNews for Stanford scientist rankings and being selected as one of the best presenters at ICBSP 2023.';
-    }
-    if (q.includes('recent') || q.includes('publication') || q.includes('paper')) {
-      const latest = [...journalData].sort((a, b) => Number(b.year) - Number(a.year)).slice(0, 3)
-        .map((p) => `• ${p.year}: ${p.title}`).join('\n');
-      return `Here are recent works:\n${latest}`;
-    }
-    if (q.includes('conference') || q.includes('presenter')) {
-      const conf = conferenceData.slice(0, 3).map((c) => `• ${c.year}: ${c.title}`).join('\n');
-      return `Selected conference works:\n${conf}`;
-    }
-    if (q.includes('news') || q.includes('feature') || q.includes('recognition')) {
-      const highlights = newsData.map((n) => `• ${n.date}: ${n.title}`).join('\n');
-      return `Recent highlights:\n${highlights}`;
-    }
-    const matched = allWorks.filter((item) => {
-      const blob = `${item.title} ${item.authors || ''} ${item.journal || ''} ${item.venue || ''}`.toLowerCase();
-      return q.split(/\s+/).some((t) => t.length > 4 && blob.includes(t));
-    }).slice(0, 3);
-    if (matched.length) {
-      return `I found these related works:\n${matched.map((m) => `• [${m.type}] ${m.year}: ${m.title}`).join('\n')}`;
-    }
-    return 'I can help with Francis’ profile, publications, recognitions, affiliations, and research expertise. Please ask within those topics.';
-  }
+  const chatHistory = [];
 
   async function ask() {
     const question = input.value.trim();
@@ -780,14 +781,27 @@ function initializeChatbot() {
     const thinkingBubble = messages.lastElementChild;
     send.disabled = true;
     try {
-      const grounding = `PROFILE:\n${profileContext}\n\nNEWS:\n${newsData.map((n) => `${n.date} - ${n.title}`).join('\n')}\n\nWORKS:\n${allWorks.slice(0, 60).map((w) => `${w.year} | ${w.title}`).join('\n')}`;
-      const llmPrompt = `You are Francis AI, a professional profile assistant.\nRules:\n1) Answer only about Francis Jesmar P. Montalbo.\n2) Use only the provided grounding data.\n3) If not in data, clearly say it is not available.\n\n${grounding}\n\nUser question: ${question}`;
+      const grounding = `PROFILE:\n${profileContext}\n\nNEWS:\n${newsData.map((n) => `${n.date} - ${n.title}`).join('\n')}\n\nWORKS:\n${allWorks.slice(0, 80).map((w) => `${w.year} | ${w.title}`).join('\n')}`;
+      chatHistory.push({ role: 'user', content: question });
+      const historyText = chatHistory.slice(-8).map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n');
+      const llmPrompt = `You are Francis AI, a true LLM chatbot for this portfolio website.
+Be accurate, natural, and concise.
+If the question is about Francis, prioritize the supplied profile/news/works data.
+If the question is outside Francis, still answer helpfully.
+
+${grounding}
+
+Conversation so far:
+${historyText}
+ASSISTANT:`;
       const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(llmPrompt)}`);
       if (!response.ok) throw new Error('Cloud LLM unavailable');
       const text = (await response.text()).trim();
-      thinkingBubble.textContent = text || fallbackAnswer(question);
+      const finalText = text || 'I could not generate a response right now. Please try again.';
+      thinkingBubble.textContent = finalText;
+      chatHistory.push({ role: 'assistant', content: finalText });
     } catch (err) {
-      thinkingBubble.textContent = fallbackAnswer(question);
+      thinkingBubble.textContent = 'The LLM service is temporarily unavailable. Please try again in a moment.';
     } finally {
       send.disabled = false;
     }


### PR DESCRIPTION
### Motivation
- Make the on-page chatbot behave as a real LLM-backed conversational assistant with short-term memory rather than a rigid canned Q/A tree.
- Provide expandable news items that can show an on-demand, concise AI-generated summary of the linked article to surface relevant highlights.
- Improve UX by generating summaries only when requested to avoid slowing initial page loads.

### Description
- Added an async `generateNewsSummary` helper that fetches article text via `https://r.jina.ai/` and requests a concise (max 4 bullets) summary from the text model for a given news item.
- Updated the news rendering to include a `<details>` expander and a `Generate` button per item that triggers on-demand summary generation and injects the result into the card.
- Replaced the old rule‑based `fallbackAnswer` tree with a rolling `chatHistory` (keeps the last 8 turns) and updated the LLM prompt to use the conversation history and grounding (profile/news/works) so replies come from the model when available.
- Improved error handling to surface a clear service-unavailable message and to fall back to a concise failure notice rather than leaking old canned logic.

### Testing
- `node --check js/script.js` completed successfully and reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc21d31f208327b8847b7745c55759)