### PR TITLE
Add floating Francis AI chatbot with RAG retrieval and expandable news summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,24 +711,10 @@
     </section>
 
     <!-- Personal Chatbot Section -->
-    <section id="chatbot" class="py-20 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
+    <section id="chatbot" class="py-12 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
       <div class="max-w-4xl mx-auto px-4">
         <h2 class="text-3xl font-semibold text-accent2 mb-3">Ask Francis AI</h2>
-        <p class="text-sm text-gray-300 mb-6">A profile-grounded assistant that works instantly and answers only about Dr. Francis Jesmar P. Montalbo (research, work, skills, and achievements).</p>
-        <div class="publication-card">
-          <div id="chatbot-messages" class="rounded-md bg-primaryDark border border-primary p-4 text-sm text-gray-100 min-h-[260px] max-h-[420px] overflow-y-auto space-y-3 mb-4">
-            <div class="max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100">Hi! I’m Francis AI. Ask me about Francis’ publications, awards, affiliations, and expertise.</div>
-          </div>
-          <div class="flex flex-wrap gap-2 mb-4">
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="Show recent publications by Francis.">Recent Works</button>
-          </div>
-          <div class="flex gap-3">
-            <input id="chatbot-input" type="text" placeholder="Type your question..." class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
-            <button id="chatbot-send" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Ask</button>
-          </div>
-        </div>
+        <p class="text-sm text-gray-300">Click the floating chat button (bottom-left) to open Francis AI.</p>
       </div>
     </section>
 
@@ -791,6 +777,28 @@
     <div id="backToTop" class="fixed bottom-5 right-5 hidden text-4xl text-accent2 bg-transparent cursor-pointer transform transition-transform duration-200 hover:text-accent hover:scale-125" role="button" aria-label="Back to top">
       <!-- Use a stand-alone arrow emoji for the return-home button with a hover effect -->
       ⬆️
+    </div>
+
+    <button id="chatbot-fab" class="fixed bottom-6 left-6 z-50 bg-accent2 text-dark px-4 py-3 rounded-full shadow-xl hover:bg-accent transition-colors font-semibold">
+      <i class="fa-solid fa-comments mr-2"></i> Chat with Francis AI
+    </button>
+    <div id="chatbot-widget" class="hidden fixed bottom-24 left-6 z-50 w-[360px] max-w-[92vw] rounded-2xl border border-primary bg-[#10180f] shadow-2xl overflow-hidden">
+      <div class="px-4 py-3 bg-primaryDark border-b border-primary flex items-center justify-between">
+        <p class="text-sm font-semibold text-accent2">Francis AI • Live</p>
+        <button id="chatbot-close" class="text-gray-300 hover:text-white"><i class="fa-solid fa-xmark"></i></button>
+      </div>
+      <p id="chatbot-status" class="text-xs text-gray-400 px-4 py-2 border-b border-primary">Online mode enabled.</p>
+      <div id="chatbot-messages" class="p-4 text-sm text-gray-100 min-h-[300px] max-h-[420px] overflow-y-auto space-y-3"></div>
+      <div class="p-3 border-t border-primary bg-primaryDark/70">
+        <div class="flex flex-wrap gap-2 mb-3">
+          <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
+          <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
+        </div>
+        <div class="flex gap-2">
+          <input id="chatbot-input" type="text" placeholder="Ask anything..." class="flex-grow px-3 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+          <button id="chatbot-send" class="px-3 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Send</button>
+        </div>
+      </div>
     </div>
 
     <!-- Scripts -->

--- a/js/script.js
+++ b/js/script.js
@@ -388,7 +388,8 @@ const newsData = [
   {
     date: "2026-05-05",
     title: "National Spotlight: Recognized in OneNews Stanford Scientists Feature",
-    summary: "I was highlighted in OneNews’ coverage of the Stanford global scientist rankings—reinforcing my standing as an internationally recognized Filipino researcher contributing high-impact AI and biomedical signal processing work.",
+    summary: "OneNews reported that the Philippines had 58 scientists in Stanford’s global list (up from 50 the prior year), and I was recognized among Filipino researchers contributing visible international impact.",
+    expandedSummary: "The OneNews feature discusses the Philippines’ representation in Stanford’s global scientist ranking and notes that the country still trails several ASEAN peers despite year-over-year gains. Within this context, my inclusion highlights sustained visibility in international research and reflects the broader relevance of my AI and biomedical work.",
     tags: ["media-feature", "stanford-top-2%", "research-impact"],
     link: "https://www.onenews.ph/articles/phl-has-fewest-scientists-in-asean-stanford-list",
     linkLabel: "Read feature",
@@ -397,7 +398,8 @@ const newsData = [
   {
     date: "2023-10-22",
     title: "ICBSP 2023: Selected as One of the Best Presenters",
-    summary: "At ICBSP 2023, my presentation was selected among the conference’s best presenters—reflecting the clarity, novelty, and applied value of my research in biomedical imaging and AI.",
+    summary: "ICBSP 2023 in Singapore gathered global delegates and featured four oral sessions where one best oral presenter was selected per session; I was selected as one of the best presenters.",
+    expandedSummary: "The official ICBSP 2023 page confirms a successful hybrid international conference with broad participation across countries, keynote talks from recognized experts, and peer-reviewed proceedings published by ACM (indexed by Ei Compendex and Scopus). Being selected as one of the best presenters places my work among the strongest session-level contributions at a competitive international venue.",
     tags: ["best-presenter", "international-conference", "ai-research"],
     link: "https://www.icbsp.org/icbsp2023.html",
     linkLabel: "Conference page",
@@ -670,16 +672,21 @@ function initializeNews() {
 
   function render(items) {
     list.innerHTML = '';
-    items.forEach((item) => {
+    items.forEach((item, index) => {
       const tags = (item.tags || []).map((tag) => `<span class="badge badge-default">#${tag}</span>`).join(' ');
       const article = document.createElement('article');
+      const summaryId = `news-expanded-${index}-${item.date}`.replace(/[^a-zA-Z0-9-_]/g, '');
       article.className = 'publication-card';
       article.innerHTML = `
         <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
-          <div>
+          <div class="w-full">
             <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
             <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
             <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            <details class="mt-3">
+              <summary class="cursor-pointer text-sm text-accent">Expand: detailed summary</summary>
+              <p id="${summaryId}" class="text-sm text-gray-300 mt-2">${item.expandedSummary || item.summary}</p>
+            </details>
             <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
           </div>
           ${item.link ? `<a href="${item.link}" target="_blank" class="badge badge-code whitespace-nowrap mt-1">${item.linkLabel || 'Read more'}</a>` : ''}
@@ -716,82 +723,143 @@ function initializeChatbot() {
   const input = document.getElementById('chatbot-input');
   const send = document.getElementById('chatbot-send');
   const chips = document.querySelectorAll('.chatbot-chip');
-  if (!messages || !input || !send) return;
+  const fab = document.getElementById('chatbot-fab');
+  const widget = document.getElementById('chatbot-widget');
+  const closeBtn = document.getElementById('chatbot-close');
+  const status = document.getElementById('chatbot-status');
+  if (!messages || !input || !send || !fab || !widget || !closeBtn || !status) return;
 
   const allWorks = [
     ...journalData.map((w) => ({ ...w, type: 'Journal' })),
     ...conferenceData.map((w) => ({ ...w, type: 'Conference' })),
     ...chapterData.map((w) => ({ ...w, type: 'Chapter' }))
   ];
+  const ragCorpus = [
+    ...journalData.map((item) => ({
+      type: 'journal',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.journal || ''} ${item.doi || ''}`,
+      payload: `${item.year || ''} | Journal | ${item.title || ''}${item.journal ? ` (${item.journal})` : ''}`
+    })),
+    ...conferenceData.map((item) => ({
+      type: 'conference',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.venue || ''} ${item.doi || ''}`,
+      payload: `${item.year || ''} | Conference | ${item.title || ''}${item.venue ? ` (${item.venue})` : ''}`
+    })),
+    ...chapterData.map((item) => ({
+      type: 'chapter',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.book || ''}`,
+      payload: `${item.year || ''} | Chapter | ${item.title || ''}${item.book ? ` (${item.book})` : ''}`
+    })),
+    ...newsData.map((item) => ({
+      type: 'news',
+      title: item.title || '',
+      text: `${item.date || ''} ${item.title || ''} ${item.summary || ''} ${(item.tags || []).join(' ')}`,
+      payload: `${item.date || ''} | News | ${item.title || ''} — ${item.summary || ''}`
+    }))
+  ];
+
+  function tokenize(text) {
+    return (text || '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((t) => t.length > 2);
+  }
+
+  function retrieveContext(query, limit = 8) {
+    const qTokens = tokenize(query);
+    const qSet = new Set(qTokens);
+    if (!qSet.size) return [];
+    const scored = ragCorpus.map((doc) => {
+      const tokens = tokenize(doc.text);
+      let score = 0;
+      tokens.forEach((token) => {
+        if (qSet.has(token)) score += 1;
+      });
+      if (qTokens.some((t) => (doc.title || '').toLowerCase().includes(t))) score += 3;
+      if (doc.type === 'news' && qTokens.some((t) => ['news', 'award', 'recognition', 'feature'].includes(t))) score += 2;
+      return { ...doc, score };
+    }).filter((doc) => doc.score > 0);
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit).map((doc) => doc.payload);
+  }
 
   function addBubble(text, role = 'assistant') {
+    const row = document.createElement('div');
+    row.className = `flex items-start gap-2 ${role === 'user' ? 'justify-end' : ''}`;
+    const avatar = document.createElement('div');
+    avatar.className = `w-8 h-8 rounded-full flex items-center justify-center font-bold ${role === 'user' ? 'bg-accent2 text-dark order-2' : 'bg-accent text-dark'}`;
+    avatar.textContent = role === 'user' ? 'You' : 'AI';
     const bubble = document.createElement('div');
     bubble.className = role === 'user'
-      ? 'max-w-[85%] ml-auto rounded-lg px-3 py-2 bg-accent2 text-dark'
-      : 'max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100';
+      ? 'max-w-[80%] rounded-2xl rounded-tr-sm px-4 py-3 bg-accent2 text-dark shadow'
+      : 'max-w-[80%] rounded-2xl rounded-tl-sm px-4 py-3 bg-tertiary text-gray-100 shadow';
     bubble.textContent = text;
-    messages.appendChild(bubble);
+    row.appendChild(avatar);
+    row.appendChild(bubble);
+    messages.appendChild(row);
     messages.scrollTop = messages.scrollHeight;
+    return bubble;
   }
 
-  function fallbackAnswer(question) {
-    const q = question.toLowerCase();
-    if (!q.includes('francis') && /(who are you|weather|politics|stock|bitcoin|movie|recipe)/.test(q)) {
-      return 'I can only answer questions specifically about Francis Jesmar P. Montalbo and his profile/work.';
+  async function callLLM(messagesPayload) {
+    const prompt = messagesPayload.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n\n');
+    const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(prompt)}`);
+    if (!response.ok) {
+      throw new Error(`LLM request failed (${response.status})`);
     }
-    if (q.includes('who is') || q.includes('bio') || q.includes('introduce')) {
-      return 'Dr. Francis Jesmar P. Montalbo is an Associate Professor, Research Scientist, AI & Deep Learning Specialist, and Software Engineer affiliated with Batangas State University.';
-    }
-    if (q.includes('research') || q.includes('area') || q.includes('expert')) {
-      return 'Francis focuses on medical imaging AI, deep learning, biomedical signal processing, and computer vision, with applications in diagnostics and healthcare.';
-    }
-    if (q.includes('recognition') || q.includes('award') || q.includes('best presenter') || q.includes('stanford')) {
-      return 'Notable recognitions include being featured in OneNews for Stanford scientist rankings and being selected as one of the best presenters at ICBSP 2023.';
-    }
-    if (q.includes('recent') || q.includes('publication') || q.includes('paper')) {
-      const latest = [...journalData].sort((a, b) => Number(b.year) - Number(a.year)).slice(0, 3)
-        .map((p) => `• ${p.year}: ${p.title}`).join('\n');
-      return `Here are recent works:\n${latest}`;
-    }
-    if (q.includes('conference') || q.includes('presenter')) {
-      const conf = conferenceData.slice(0, 3).map((c) => `• ${c.year}: ${c.title}`).join('\n');
-      return `Selected conference works:\n${conf}`;
-    }
-    if (q.includes('news') || q.includes('feature') || q.includes('recognition')) {
-      const highlights = newsData.map((n) => `• ${n.date}: ${n.title}`).join('\n');
-      return `Recent highlights:\n${highlights}`;
-    }
-    const matched = allWorks.filter((item) => {
-      const blob = `${item.title} ${item.authors || ''} ${item.journal || ''} ${item.venue || ''}`.toLowerCase();
-      return q.split(/\s+/).some((t) => t.length > 4 && blob.includes(t));
-    }).slice(0, 3);
-    if (matched.length) {
-      return `I found these related works:\n${matched.map((m) => `• [${m.type}] ${m.year}: ${m.title}`).join('\n')}`;
-    }
-    return 'I can help with Francis’ profile, publications, recognitions, affiliations, and research expertise. Please ask within those topics.';
+    return (await response.text()).trim();
   }
+
+  const chatHistory = [];
 
   async function ask() {
     const question = input.value.trim();
     if (!question) return;
     addBubble(question, 'user');
     input.value = '';
-    addBubble('Thinking…');
-    const thinkingBubble = messages.lastElementChild;
+    const thinkingBubble = addBubble('Thinking…');
     send.disabled = true;
     try {
-      const grounding = `PROFILE:\n${profileContext}\n\nNEWS:\n${newsData.map((n) => `${n.date} - ${n.title}`).join('\n')}\n\nWORKS:\n${allWorks.slice(0, 60).map((w) => `${w.year} | ${w.title}`).join('\n')}`;
-      const llmPrompt = `You are Francis AI, a professional profile assistant.\nRules:\n1) Answer only about Francis Jesmar P. Montalbo.\n2) Use only the provided grounding data.\n3) If not in data, clearly say it is not available.\n\n${grounding}\n\nUser question: ${question}`;
-      const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(llmPrompt)}`);
-      if (!response.ok) throw new Error('Cloud LLM unavailable');
-      const text = (await response.text()).trim();
-      thinkingBubble.textContent = text || fallbackAnswer(question);
+      const retrieved = retrieveContext(question, 10);
+      const grounding = `PROFILE:\n${profileContext}\n\nRETRIEVED_CONTEXT:\n${retrieved.length ? retrieved.join('\n') : 'No highly relevant matches found.'}`;
+      chatHistory.push({ role: 'user', content: question });
+      const payload = [
+        {
+          role: 'system',
+          content: `You are Francis AI, a modern assistant for this portfolio website.
+Prioritize accuracy and clarity.
+Use RETRIEVED_CONTEXT first when answering profile-related queries.
+If context is insufficient, explicitly say so instead of inventing details.
+${grounding}`
+        },
+        ...chatHistory.slice(-8)
+      ];
+      status.textContent = 'Thinking...';
+      const text = await callLLM(payload);
+      const finalText = text || 'I could not generate a response right now. Please try again.';
+      thinkingBubble.textContent = finalText;
+      chatHistory.push({ role: 'assistant', content: finalText });
+      status.textContent = 'Online mode enabled.';
     } catch (err) {
-      thinkingBubble.textContent = fallbackAnswer(question);
+      thinkingBubble.textContent = err.message || 'The LLM service is temporarily unavailable. Please try again in a moment.';
+      status.textContent = 'Connection error. Please try again.';
     } finally {
       send.disabled = false;
     }
   }
+
+  fab.addEventListener('click', () => {
+    widget.classList.remove('hidden');
+    fab.classList.add('hidden');
+    if (!messages.dataset.booted) {
+      addBubble('Hi! I’m Francis AI. Ask anything—especially about Francis, his works, and achievements.');
+      messages.dataset.booted = '1';
+    }
+  });
+  closeBtn.addEventListener('click', () => {
+    widget.classList.add('hidden');
+    fab.classList.remove('hidden');
+  });
 
   send.addEventListener('click', ask);
   input.addEventListener('keydown', (event) => {


### PR DESCRIPTION
### Motivation
- Provide an on-page, profile-grounded assistant that surfaces publications/news context and answers queries without cluttering the main layout. 
- Improve discoverability of news items by adding expandable detailed summaries. 
- Modernize chat UX with a floating action button and persistent widget that can retrieve contextual snippets from on-page data.

### Description
- Replaced the previous inline chatbot block in `index.html` with a floating action button `#chatbot-fab` and a collapsible widget `#chatbot-widget`, adjusted section spacing, and added a compact status and close control. 
- Enhanced the news items in `js/script.js` by updating `newsData` content, adding `expandedSummary` fields, and rendering an accessible `details`/`summary` element per news item with unique IDs. 
- Implemented a lightweight RAG-style retriever in `js/script.js` that builds a `ragCorpus` from `journalData`, `conferenceData`, `chapterData`, and `newsData`, and provides `tokenize` and `retrieveContext` functions for relevance scoring. 
- Reworked the chatbot flow to maintain `chatHistory`, add styled message bubbles with avatars, show a `Thinking...` indicator, call an external LLM endpoint via `callLLM`, and surface online/error status; added FAB open/close handlers and chip quick-questions.