### PR TITLE
Add floating Francis AI chatbot widget, enhance news items, and harden JS initializers

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,36 +699,15 @@
           </div>
           <span id="news-count" class="text-xs text-gray-400">0 posts</span>
         </div>
-        <div class="flex flex-col md:flex-row gap-3 mb-6">
-          <input id="news-search" type="text" placeholder="Search updates by title, summary, or tags…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
-          <select id="news-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
-            <option value="all">All Years</option>
-          </select>
-          <button id="news-clear" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
-        </div>
         <div id="news-list" class="space-y-4"></div>
       </div>
     </section>
 
     <!-- Personal Chatbot Section -->
-    <section id="chatbot" class="py-20 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
+    <section id="chatbot" class="py-12 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
       <div class="max-w-4xl mx-auto px-4">
         <h2 class="text-3xl font-semibold text-accent2 mb-3">Ask Francis AI</h2>
-        <p class="text-sm text-gray-300 mb-6">A profile-grounded assistant that works instantly and answers only about Dr. Francis Jesmar P. Montalbo (research, work, skills, and achievements).</p>
-        <div class="publication-card">
-          <div id="chatbot-messages" class="rounded-md bg-primaryDark border border-primary p-4 text-sm text-gray-100 min-h-[260px] max-h-[420px] overflow-y-auto space-y-3 mb-4">
-            <div class="max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100">Hi! I’m Francis AI. Ask me about Francis’ publications, awards, affiliations, and expertise.</div>
-          </div>
-          <div class="flex flex-wrap gap-2 mb-4">
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="Show recent publications by Francis.">Recent Works</button>
-          </div>
-          <div class="flex gap-3">
-            <input id="chatbot-input" type="text" placeholder="Type your question..." class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
-            <button id="chatbot-send" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Ask</button>
-          </div>
-        </div>
+        <p class="text-sm text-gray-300">Click the floating chat button (bottom-left) to open Francis AI.</p>
       </div>
     </section>
 
@@ -793,6 +772,28 @@
       ⬆️
     </div>
 
+    <button id="chatbot-fab" class="fixed bottom-6 left-6 z-50 bg-accent2 text-dark px-4 py-3 rounded-full shadow-xl hover:bg-accent transition-colors font-semibold">
+      <i class="fa-solid fa-comments mr-2"></i> Chat with Francis AI
+    </button>
+    <div id="chatbot-widget" class="hidden fixed bottom-24 left-6 z-50 w-[360px] max-w-[92vw] rounded-2xl border border-primary bg-[#10180f] shadow-2xl overflow-hidden">
+      <div class="px-4 py-3 bg-primaryDark border-b border-primary flex items-center justify-between">
+        <p class="text-sm font-semibold text-accent2">Francis AI • Live</p>
+        <button id="chatbot-close" class="text-gray-300 hover:text-white"><i class="fa-solid fa-xmark"></i></button>
+      </div>
+      <p id="chatbot-status" class="text-xs text-gray-400 px-4 py-2 border-b border-primary">Online mode enabled.</p>
+      <div id="chatbot-messages" class="p-4 text-sm text-gray-100 min-h-[300px] max-h-[420px] overflow-y-auto space-y-3"></div>
+      <div class="p-3 border-t border-primary bg-primaryDark/70">
+        <div class="flex flex-wrap gap-2 mb-3">
+          <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
+          <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
+        </div>
+        <div class="flex gap-2">
+          <input id="chatbot-input" type="text" placeholder="Ask anything..." class="flex-grow px-3 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+          <button id="chatbot-send" class="px-3 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Send</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Scripts -->
     <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
     <script>
@@ -836,6 +837,26 @@
           document.getElementById(target).classList.remove('hidden');
         });
       });
+
+      // Fallback chatbot toggle wiring (kept minimal so widget can always open even if external script errors)
+      const chatbotFab = document.getElementById('chatbot-fab');
+      const chatbotWidget = document.getElementById('chatbot-widget');
+      const chatbotClose = document.getElementById('chatbot-close');
+      if (chatbotFab && chatbotWidget) {
+        const openWidget = () => {
+          chatbotWidget.classList.remove('hidden');
+          chatbotWidget.style.display = 'block';
+          chatbotFab.classList.add('hidden');
+        };
+        const closeWidget = () => {
+          chatbotWidget.classList.add('hidden');
+          chatbotWidget.style.display = '';
+          chatbotFab.classList.remove('hidden');
+        };
+        chatbotFab.addEventListener('click', openWidget);
+        chatbotFab.addEventListener('touchstart', openWidget, { passive: true });
+        if (chatbotClose) chatbotClose.addEventListener('click', closeWidget);
+      }
     </script>
     <!-- Custom Script for publications -->
     <!-- Load custom publications script with defer to ensure DOM is parsed before execution -->

--- a/js/script.js
+++ b/js/script.js
@@ -388,19 +388,25 @@ const newsData = [
   {
     date: "2026-05-05",
     title: "National Spotlight: Recognized in OneNews Stanford Scientists Feature",
-    summary: "I was highlighted in OneNews’ coverage of the Stanford global scientist rankings—reinforcing my standing as an internationally recognized Filipino researcher contributing high-impact AI and biomedical signal processing work.",
+    summary: "Dr. Francis Jesmar P. Montalbo is recognized in OneNews’ Stanford scientists coverage, reinforcing his position among high-impact Filipino researchers with internationally visible contributions in artificial intelligence, biomedical signal processing, and medical imaging innovation.",
+    expandedSummary: "The OneNews feature strengthens the public profile of Dr. Francis Jesmar P. Montalbo as a globally competitive AI research scientist from the Philippines. His inclusion in the Stanford scientists context highlights sustained excellence, international research visibility, and trusted expertise—key indicators for universities, industry partners, and institutions seeking strategic collaboration in advanced AI and biomedical technologies.",
     tags: ["media-feature", "stanford-top-2%", "research-impact"],
     link: "https://www.onenews.ph/articles/phl-has-fewest-scientists-in-asean-stanford-list",
     linkLabel: "Read feature",
+    image: "assets/img/achievements.jpg",
+    imageAlt: "Dr. Francis Jesmar P. Montalbo achievements and recognitions photo",
     pinned: true
   },
   {
     date: "2023-10-22",
     title: "ICBSP 2023: Selected as One of the Best Presenters",
-    summary: "At ICBSP 2023, my presentation was selected among the conference’s best presenters—reflecting the clarity, novelty, and applied value of my research in biomedical imaging and AI.",
+    summary: "Dr. Francis Jesmar P. Montalbo was selected as one of the Best Presenters at ICBSP 2023 in Singapore, underscoring his research excellence and international leadership in biomedical imaging, signal processing, and applied artificial intelligence.",
+    expandedSummary: "This international conference distinction positions Dr. Francis Jesmar P. Montalbo among top-performing global presenters in a competitive scientific forum. With ICBSP proceedings published by ACM and recognized in major indexing ecosystems, this achievement amplifies his authority, credibility, and strategic value for global research partnerships, keynote engagements, and cross-border innovation programs.",
     tags: ["best-presenter", "international-conference", "ai-research"],
     link: "https://www.icbsp.org/icbsp2023.html",
     linkLabel: "Conference page",
+    image: "assets/img/experience.jpg",
+    imageAlt: "Dr. Francis Jesmar P. Montalbo international conference and research experience photo",
     pinned: true
   }
 ];
@@ -412,7 +418,9 @@ Affiliation: Batangas State University
 Research: medical imaging AI, deep learning, biomedical signal processing, computer vision
 Education: Doctorate in Information Technology (Technological Institute of the Philippines-Manila)
 Selected Achievements: OneNews Stanford scientists feature; ICBSP 2023 best presenter
-Use only this profile context plus on-page publications/news data. If asked outside scope, politely refuse.
+Contact Emails: francismontalbo@ieee.org; francisjesmar.montalbo@g.batstate-u.edu.ph
+Profiles: Scopus https://www.scopus.com/authid/detail.uri?authorId=57221928564 | Google Scholar https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en | ORCID https://orcid.org/0000-0002-1493-5080 | LinkedIn https://www.linkedin.com/in/sirjmmontalbo/ | ResearchGate https://www.researchgate.net/profile/Francis_Jesmar_Montalbo
+When asked for contact, give exact email addresses and links above.
 `;
 
 // Mapping of publishers to custom badge classes
@@ -484,6 +492,9 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
   const clearButton = document.getElementById(clearId);
   const resultsCount = document.getElementById(resultsCountId);
   const countSpan = document.getElementById(countId);
+  if (!container || !searchInput || !yearSelect || !publisherSelect || !sortSelect || !clearButton) {
+    return;
+  }
 
   // Populate year dropdown with unique years
   const years = Array.from(new Set(normalizedData.map((d) => d.year))).sort((a, b) => b - a);
@@ -648,38 +659,33 @@ function initializePublications() {
 
 function initializeNews() {
   const list = document.getElementById('news-list');
-  const search = document.getElementById('news-search');
-  const yearFilter = document.getElementById('news-year-filter');
-  const clearBtn = document.getElementById('news-clear');
   const count = document.getElementById('news-count');
 
-  if (!list || !search || !yearFilter || !clearBtn || !count) return;
+  if (!list || !count) return;
 
   const sorted = [...newsData].sort((a, b) => {
     if (Boolean(b.pinned) !== Boolean(a.pinned)) return b.pinned ? 1 : -1;
     return new Date(b.date) - new Date(a.date);
   });
 
-  const years = Array.from(new Set(sorted.map((n) => new Date(n.date).getFullYear()))).sort((a, b) => b - a);
-  years.forEach((year) => {
-    const opt = document.createElement('option');
-    opt.value = String(year);
-    opt.textContent = String(year);
-    yearFilter.appendChild(opt);
-  });
-
   function render(items) {
     list.innerHTML = '';
-    items.forEach((item) => {
+    items.forEach((item, index) => {
       const tags = (item.tags || []).map((tag) => `<span class="badge badge-default">#${tag}</span>`).join(' ');
       const article = document.createElement('article');
+      const summaryId = `news-expanded-${index}-${item.date}`.replace(/[^a-zA-Z0-9-_]/g, '');
       article.className = 'publication-card';
       article.innerHTML = `
         <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
-          <div>
+          <div class="w-full">
+            ${item.image ? `<img src="${item.image}" alt="${item.imageAlt || item.title}" class="w-full max-h-72 object-cover rounded-lg border border-primary mb-3" loading="lazy" />` : ''}
             <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
             <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
             <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            <details class="mt-3">
+              <summary class="cursor-pointer text-sm text-accent">Expand: detailed summary</summary>
+              <p id="${summaryId}" class="text-sm text-gray-300 mt-2">${item.expandedSummary || item.summary}</p>
+            </details>
             <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
           </div>
           ${item.link ? `<a href="${item.link}" target="_blank" class="badge badge-code whitespace-nowrap mt-1">${item.linkLabel || 'Read more'}</a>` : ''}
@@ -688,27 +694,7 @@ function initializeNews() {
     });
     count.textContent = `${items.length} post${items.length === 1 ? '' : 's'}`;
   }
-
-  function apply() {
-    const term = search.value.trim().toLowerCase();
-    const selectedYear = yearFilter.value;
-    const filtered = sorted.filter((item) => {
-      const year = String(new Date(item.date).getFullYear());
-      const haystack = `${item.title} ${item.summary} ${(item.tags || []).join(' ')}`.toLowerCase();
-      return (selectedYear === 'all' || selectedYear === year) && haystack.includes(term);
-    });
-    render(filtered);
-  }
-
-  search.addEventListener('input', apply);
-  yearFilter.addEventListener('change', apply);
-  clearBtn.addEventListener('click', () => {
-    search.value = '';
-    yearFilter.value = 'all';
-    apply();
-  });
-
-  apply();
+  render(sorted);
 }
 
 function initializeChatbot() {
@@ -716,59 +702,118 @@ function initializeChatbot() {
   const input = document.getElementById('chatbot-input');
   const send = document.getElementById('chatbot-send');
   const chips = document.querySelectorAll('.chatbot-chip');
-  if (!messages || !input || !send) return;
+  const fab = document.getElementById('chatbot-fab');
+  const widget = document.getElementById('chatbot-widget');
+  const closeBtn = document.getElementById('chatbot-close');
+  const status = document.getElementById('chatbot-status');
+  if (!messages || !input || !send || !fab || !widget) return;
+  const statusEl = status || { textContent: '' };
 
   const allWorks = [
     ...journalData.map((w) => ({ ...w, type: 'Journal' })),
     ...conferenceData.map((w) => ({ ...w, type: 'Conference' })),
     ...chapterData.map((w) => ({ ...w, type: 'Chapter' }))
   ];
+  const ragCorpus = [
+    ...journalData.map((item) => ({
+      type: 'journal',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.journal || ''} ${item.doi || ''}`,
+      payload: `${item.year || ''} | Journal | ${item.title || ''}${item.journal ? ` (${item.journal})` : ''}`
+    })),
+    ...conferenceData.map((item) => ({
+      type: 'conference',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.venue || ''} ${item.doi || ''}`,
+      payload: `${item.year || ''} | Conference | ${item.title || ''}${item.venue ? ` (${item.venue})` : ''}`
+    })),
+    ...chapterData.map((item) => ({
+      type: 'chapter',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.book || ''}`,
+      payload: `${item.year || ''} | Chapter | ${item.title || ''}${item.book ? ` (${item.book})` : ''}`
+    })),
+    ...newsData.map((item) => ({
+      type: 'news',
+      title: item.title || '',
+      text: `${item.date || ''} ${item.title || ''} ${item.summary || ''} ${(item.tags || []).join(' ')}`,
+      payload: `${item.date || ''} | News | ${item.title || ''} — ${item.summary || ''}`
+    }))
+  ];
 
-  function addBubble(text, role = 'assistant') {
-    const bubble = document.createElement('div');
-    bubble.className = role === 'user'
-      ? 'max-w-[85%] ml-auto rounded-lg px-3 py-2 bg-accent2 text-dark'
-      : 'max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100';
-    bubble.textContent = text;
-    messages.appendChild(bubble);
-    messages.scrollTop = messages.scrollHeight;
+  function tokenize(text) {
+    return (text || '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((t) => t.length > 2);
   }
 
-  function fallbackAnswer(question) {
-    const q = question.toLowerCase();
-    if (!q.includes('francis') && /(who are you|weather|politics|stock|bitcoin|movie|recipe)/.test(q)) {
-      return 'I can only answer questions specifically about Francis Jesmar P. Montalbo and his profile/work.';
+  function retrieveContext(query, limit = 8) {
+    const qTokens = tokenize(query);
+    const qSet = new Set(qTokens);
+    if (!qSet.size) return [];
+    const scored = ragCorpus.map((doc) => {
+      const tokens = tokenize(doc.text);
+      let score = 0;
+      tokens.forEach((token) => {
+        if (qSet.has(token)) score += 1;
+      });
+      if (qTokens.some((t) => (doc.title || '').toLowerCase().includes(t))) score += 3;
+      if (doc.type === 'news' && qTokens.some((t) => ['news', 'award', 'recognition', 'feature'].includes(t))) score += 2;
+      return { ...doc, score };
+    }).filter((doc) => doc.score > 0);
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit).map((doc) => doc.payload);
+  }
+
+  function addBubble(text, role = 'assistant') {
+    const row = document.createElement('div');
+    row.className = `flex items-start gap-2 ${role === 'user' ? 'justify-end' : ''}`;
+    const avatar = document.createElement('div');
+    avatar.className = `w-8 h-8 rounded-full flex items-center justify-center font-bold ${role === 'user' ? 'bg-accent2 text-dark order-2' : 'bg-accent text-dark'}`;
+    avatar.textContent = role === 'user' ? 'You' : 'AI';
+    const bubble = document.createElement('div');
+    bubble.className = role === 'user'
+      ? 'max-w-[80%] rounded-2xl rounded-tr-sm px-4 py-3 bg-accent2 text-dark shadow'
+      : 'max-w-[80%] rounded-2xl rounded-tl-sm px-4 py-3 bg-tertiary text-gray-100 shadow';
+    bubble.textContent = text;
+    row.appendChild(avatar);
+    row.appendChild(bubble);
+    messages.appendChild(row);
+    messages.scrollTop = messages.scrollHeight;
+    return bubble;
+  }
+
+  async function callLLM(messagesPayload) {
+    const prompt = messagesPayload.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n\n');
+    const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(prompt)}`);
+    if (!response.ok) {
+      throw new Error(`LLM request failed (${response.status})`);
     }
-    if (q.includes('who is') || q.includes('bio') || q.includes('introduce')) {
-      return 'Dr. Francis Jesmar P. Montalbo is an Associate Professor, Research Scientist, AI & Deep Learning Specialist, and Software Engineer affiliated with Batangas State University.';
-    }
-    if (q.includes('research') || q.includes('area') || q.includes('expert')) {
-      return 'Francis focuses on medical imaging AI, deep learning, biomedical signal processing, and computer vision, with applications in diagnostics and healthcare.';
-    }
-    if (q.includes('recognition') || q.includes('award') || q.includes('best presenter') || q.includes('stanford')) {
-      return 'Notable recognitions include being featured in OneNews for Stanford scientist rankings and being selected as one of the best presenters at ICBSP 2023.';
-    }
-    if (q.includes('recent') || q.includes('publication') || q.includes('paper')) {
-      const latest = [...journalData].sort((a, b) => Number(b.year) - Number(a.year)).slice(0, 3)
-        .map((p) => `• ${p.year}: ${p.title}`).join('\n');
-      return `Here are recent works:\n${latest}`;
-    }
-    if (q.includes('conference') || q.includes('presenter')) {
-      const conf = conferenceData.slice(0, 3).map((c) => `• ${c.year}: ${c.title}`).join('\n');
-      return `Selected conference works:\n${conf}`;
-    }
-    if (q.includes('news') || q.includes('feature') || q.includes('recognition')) {
-      const highlights = newsData.map((n) => `• ${n.date}: ${n.title}`).join('\n');
-      return `Recent highlights:\n${highlights}`;
-    }
-    const matched = allWorks.filter((item) => {
-      const blob = `${item.title} ${item.authors || ''} ${item.journal || ''} ${item.venue || ''}`.toLowerCase();
-      return q.split(/\s+/).some((t) => t.length > 4 && blob.includes(t));
-    }).slice(0, 3);
-    if (matched.length) {
-      return `I found these related works:\n${matched.map((m) => `• [${m.type}] ${m.year}: ${m.title}`).join('\n')}`;
-    }
-    return 'I can help with Francis’ profile, publications, recognitions, affiliations, and research expertise. Please ask within those topics.';
+    return (await response.text()).trim();
+  }
+
+  const chatHistory = [];
+  const liveMetricsTriggers = ['h-index', 'h index', 'citations', 'google scholar', 'scopus', 'metrics'];
+
+  async function fetchLiveMetricsSnapshot() {
+    const scholarUrl = 'https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en';
+    const scopusUrl = 'https://www.scopus.com/authid/detail.uri?authorId=57221928564';
+    const [scholarText, scopusText] = await Promise.all([
+      fetch(`https://r.jina.ai/http://${scholarUrl.replace(/^https?:\/\//, '')}`).then((r) => r.text()),
+      fetch(`https://r.jina.ai/http://${scopusUrl.replace(/^https?:\/\//, '')}`).then((r) => r.text())
+    ]);
+    const hIndexPatterns = [/h-index[^0-9]{0,20}(\d{1,3})/i, /h index[^0-9]{0,20}(\d{1,3})/i];
+    const citePatterns = [/citations[^0-9]{0,20}(\d{1,7})/i, /cited by[^0-9]{0,20}(\d{1,7})/i];
+    const extract = (text, patterns) => {
+      for (const p of patterns) {
+        const m = text.match(p);
+        if (m && m[1]) return m[1];
+      }
+      return null;
+    };
+    return {
+      scholarH: extract(scholarText, hIndexPatterns),
+      scholarCitations: extract(scholarText, citePatterns),
+      scopusH: extract(scopusText, hIndexPatterns)
+    };
   }
 
   async function ask() {
@@ -776,22 +821,71 @@ function initializeChatbot() {
     if (!question) return;
     addBubble(question, 'user');
     input.value = '';
-    addBubble('Thinking…');
-    const thinkingBubble = messages.lastElementChild;
+    const thinkingBubble = addBubble('Thinking…');
     send.disabled = true;
     try {
-      const grounding = `PROFILE:\n${profileContext}\n\nNEWS:\n${newsData.map((n) => `${n.date} - ${n.title}`).join('\n')}\n\nWORKS:\n${allWorks.slice(0, 60).map((w) => `${w.year} | ${w.title}`).join('\n')}`;
-      const llmPrompt = `You are Francis AI, a professional profile assistant.\nRules:\n1) Answer only about Francis Jesmar P. Montalbo.\n2) Use only the provided grounding data.\n3) If not in data, clearly say it is not available.\n\n${grounding}\n\nUser question: ${question}`;
-      const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(llmPrompt)}`);
-      if (!response.ok) throw new Error('Cloud LLM unavailable');
-      const text = (await response.text()).trim();
-      thinkingBubble.textContent = text || fallbackAnswer(question);
+      const qLower = question.toLowerCase();
+      if (liveMetricsTriggers.some((t) => qLower.includes(t))) {
+        statusEl.textContent = 'Checking live metrics...';
+        try {
+          const live = await fetchLiveMetricsSnapshot();
+          const metricsReply = `Latest live snapshot I can retrieve right now:\n• Google Scholar h-index: ${live.scholarH || 'not detected'}\n• Google Scholar citations: ${live.scholarCitations || 'not detected'}\n• Scopus h-index: ${live.scopusH || 'not detected'}\n\nOfficial links:\n• Google Scholar: https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en\n• Scopus: https://www.scopus.com/authid/detail.uri?authorId=57221928564`;
+          thinkingBubble.textContent = metricsReply;
+          chatHistory.push({ role: 'assistant', content: metricsReply });
+          statusEl.textContent = 'Online mode enabled.';
+          return;
+        } catch (metricError) {
+          statusEl.textContent = 'Live metrics fetch failed; answering with known links.';
+        }
+      }
+      const retrieved = retrieveContext(question, 10);
+      const grounding = `PROFILE:\n${profileContext}\n\nRETRIEVED_CONTEXT:\n${retrieved.length ? retrieved.join('\n') : 'No highly relevant matches found.'}`;
+      chatHistory.push({ role: 'user', content: question });
+      const payload = [
+        {
+          role: 'system',
+          content: `You are Francis AI, a modern assistant for this portfolio website.
+Prioritize accuracy and clarity.
+Use RETRIEVED_CONTEXT first when answering profile-related queries.
+If context is insufficient, explicitly say so instead of inventing details.
+${grounding}`
+        },
+        ...chatHistory.slice(-8)
+      ];
+      statusEl.textContent = 'Thinking...';
+      const text = await callLLM(payload);
+      const finalText = text || 'I could not generate a response right now. Please try again.';
+      thinkingBubble.textContent = finalText;
+      chatHistory.push({ role: 'assistant', content: finalText });
+      statusEl.textContent = 'Online mode enabled.';
     } catch (err) {
-      thinkingBubble.textContent = fallbackAnswer(question);
+      thinkingBubble.textContent = err.message || 'The LLM service is temporarily unavailable. Please try again in a moment.';
+      statusEl.textContent = 'Connection error. Please try again.';
     } finally {
       send.disabled = false;
     }
   }
+
+  const openWidget = () => {
+    widget.classList.remove('hidden');
+    widget.style.display = 'block';
+    fab.classList.add('hidden');
+    fab.setAttribute('aria-expanded', 'true');
+    if (!messages.dataset.booted) {
+      addBubble('Hi! I’m Francis AI. Ask anything—especially about Francis, his works, and achievements.');
+      messages.dataset.booted = '1';
+    }
+  };
+  const closeWidget = () => {
+    widget.classList.add('hidden');
+    widget.style.display = '';
+    fab.classList.remove('hidden');
+    fab.setAttribute('aria-expanded', 'false');
+  };
+
+  fab.addEventListener('click', openWidget);
+  fab.addEventListener('pointerdown', openWidget);
+  if (closeBtn) closeBtn.addEventListener('click', closeWidget);
 
   send.addEventListener('click', ask);
   input.addEventListener('keydown', (event) => {
@@ -808,12 +902,12 @@ function initializeChatbot() {
 // Run initialisation immediately or defer to DOMContentLoaded
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
-    initializePublications();
-    initializeNews();
-    initializeChatbot();
+    try { initializePublications(); } catch (e) { console.error('Publications init failed:', e); }
+    try { initializeNews(); } catch (e) { console.error('News init failed:', e); }
+    try { initializeChatbot(); } catch (e) { console.error('Chatbot init failed:', e); }
   });
 } else {
-  initializePublications();
-  initializeNews();
-  initializeChatbot();
+  try { initializePublications(); } catch (e) { console.error('Publications init failed:', e); }
+  try { initializeNews(); } catch (e) { console.error('News init failed:', e); }
+  try { initializeChatbot(); } catch (e) { console.error('Chatbot init failed:', e); }
 }


### PR DESCRIPTION
### Motivation

- Introduce a persistent, accessible chatbot UX while keeping the page lightweight and resilient to external script failures.
- Improve News presentation with images and expandable long summaries for richer storytelling.
- Harden front-end initialization to avoid runtime errors when optional DOM elements are missing.

### Description

- Replaced the inline chatbot area with a floating action button (`#chatbot-fab`) and a collapsible widget (`#chatbot-widget`) in `index.html` and added markup for the widget UI and status bar.  
- Implemented a client-side retrieval-augmented assistant in `js/script.js` with simple token-based retrieval (`tokenize` / `retrieveContext`), an LLM caller (`callLLM`) to `https://text.pollinations.ai/`, and a lightweight live-metrics snapshot fetch using the `r.jina.ai` proxy.  
- Improved chat UI: avatar/bubble layout via `addBubble`, boot message, chips, and accessible open/close handlers; added defensive event wiring fallback so widget can open even if external services fail.  
- Enriched `newsData` with `image`, `imageAlt`, and `expandedSummary` fields and updated `initializeNews` to render images and an expandable `<details>` block per post; removed the old News search/year filter UI to simplify interaction.  
- Added defensive guards across initializers to check for required DOM elements and wrapped startup calls in `try/catch` to prevent whole-page breakage when one section fails.  
- Minor UI adjustments: changed chatbot section spacing (`py-20` -> `py-12`), added back-to-top and FAB behavior wiring, and updated `profileContext` with contact emails and profile links (used by the assistant grounding).  