### PR TITLE
Modularize site data and chatbot, refactor UI to floating chat widget and streamline scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,8 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-      integrity="sha512-pn1TXwldMtM3tLk1R6U1IDB0GJQ6mHK7XxkMFv4QlqpNIZrwWN2+yT6dJ+Vd6kGJ+rHfAIkt6c0BtTgD+QiEYQ=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
     />
+    <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico" />
     <!-- AOS (Animate on Scroll) library for subtle fade animations -->
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
 
@@ -699,36 +697,15 @@
           </div>
           <span id="news-count" class="text-xs text-gray-400">0 posts</span>
         </div>
-        <div class="flex flex-col md:flex-row gap-3 mb-6">
-          <input id="news-search" type="text" placeholder="Search updates by title, summary, or tags…" class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
-          <select id="news-year-filter" class="px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none">
-            <option value="all">All Years</option>
-          </select>
-          <button id="news-clear" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Clear</button>
-        </div>
         <div id="news-list" class="space-y-4"></div>
       </div>
     </section>
 
     <!-- Personal Chatbot Section -->
-    <section id="chatbot" class="py-20 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
+    <section id="chatbot" class="py-12 bg-primaryDark text-gray-100 relative" data-aos="fade-up">
       <div class="max-w-4xl mx-auto px-4">
         <h2 class="text-3xl font-semibold text-accent2 mb-3">Ask Francis AI</h2>
-        <p class="text-sm text-gray-300 mb-6">A profile-grounded assistant that works instantly and answers only about Dr. Francis Jesmar P. Montalbo (research, work, skills, and achievements).</p>
-        <div class="publication-card">
-          <div id="chatbot-messages" class="rounded-md bg-primaryDark border border-primary p-4 text-sm text-gray-100 min-h-[260px] max-h-[420px] overflow-y-auto space-y-3 mb-4">
-            <div class="max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100">Hi! I’m Francis AI. Ask me about Francis’ publications, awards, affiliations, and expertise.</div>
-          </div>
-          <div class="flex flex-wrap gap-2 mb-4">
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
-            <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="Show recent publications by Francis.">Recent Works</button>
-          </div>
-          <div class="flex gap-3">
-            <input id="chatbot-input" type="text" placeholder="Type your question..." class="flex-grow px-4 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
-            <button id="chatbot-send" class="px-4 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Ask</button>
-          </div>
-        </div>
+        <p class="text-sm text-gray-300">Click the floating chat button (bottom-left) to open Francis AI.</p>
       </div>
     </section>
 
@@ -793,6 +770,28 @@
       ⬆️
     </div>
 
+    <button id="chatbot-fab" class="fixed bottom-6 left-6 z-50 bg-accent2 text-dark px-4 py-3 rounded-full shadow-xl hover:bg-accent transition-colors font-semibold">
+      <i class="fa-solid fa-comments mr-2"></i> Chat with Francis AI
+    </button>
+    <div id="chatbot-widget" class="hidden fixed bottom-24 left-6 z-50 w-[360px] max-w-[92vw] rounded-2xl border border-primary bg-[#10180f] shadow-2xl overflow-hidden">
+      <div class="px-4 py-3 bg-primaryDark border-b border-primary flex items-center justify-between">
+        <p class="text-sm font-semibold text-accent2">Francis AI • Live</p>
+        <button id="chatbot-close" class="text-gray-300 hover:text-white"><i class="fa-solid fa-xmark"></i></button>
+      </div>
+      <p id="chatbot-status" class="text-xs text-gray-400 px-4 py-2 border-b border-primary">Online mode enabled.</p>
+      <div id="chatbot-messages" class="p-4 text-sm text-gray-100 min-h-[300px] max-h-[420px] overflow-y-auto space-y-3"></div>
+      <div class="p-3 border-t border-primary bg-primaryDark/70">
+        <div class="flex flex-wrap gap-2 mb-3">
+          <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What are Francis' top research areas?">Research Areas</button>
+          <button class="chatbot-chip px-3 py-1 rounded-full text-xs bg-primary text-gray-100 border border-primary hover:bg-tertiary" data-question="What major recognitions has Francis received?">Recognitions</button>
+        </div>
+        <div class="flex gap-2">
+          <input id="chatbot-input" type="text" placeholder="Ask anything..." class="flex-grow px-3 py-2 rounded-md bg-primaryDark text-gray-100 border border-primary focus:ring-2 focus:ring-accent focus:outline-none" />
+          <button id="chatbot-send" class="px-3 py-2 rounded-md bg-accent2 text-dark font-medium hover:bg-accent transition-colors">Send</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Scripts -->
     <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
     <script>
@@ -836,9 +835,64 @@
           document.getElementById(target).classList.remove('hidden');
         });
       });
+
+      // Fallback chatbot toggle wiring (kept minimal so widget can always open even if external script errors)
+      const chatbotFab = document.getElementById('chatbot-fab');
+      const chatbotWidget = document.getElementById('chatbot-widget');
+      const chatbotClose = document.getElementById('chatbot-close');
+      if (chatbotFab && chatbotWidget) {
+        const openWidget = () => {
+          chatbotWidget.classList.remove('hidden');
+          chatbotWidget.style.display = 'block';
+          chatbotFab.classList.add('hidden');
+        };
+        const closeWidget = () => {
+          chatbotWidget.classList.add('hidden');
+          chatbotWidget.style.display = '';
+          chatbotFab.classList.remove('hidden');
+        };
+        chatbotFab.addEventListener('click', openWidget);
+        chatbotFab.addEventListener('touchstart', openWidget, { passive: true });
+        if (chatbotClose) chatbotClose.addEventListener('click', closeWidget);
+      }
+
+      // Fallback message handler (guarantees basic replies if external chatbot script fails to bind)
+      const chatbotMessages = document.getElementById('chatbot-messages');
+      const chatbotInput = document.getElementById('chatbot-input');
+      const chatbotSend = document.getElementById('chatbot-send');
+      if (chatbotMessages && chatbotInput && chatbotSend && !chatbotSend.dataset.boundFallback) {
+        const addFallbackBubble = (text, role = 'assistant') => {
+          const row = document.createElement('div');
+          row.className = `flex items-start gap-2 ${role === 'user' ? 'justify-end' : ''}`;
+          row.innerHTML = role === 'user'
+            ? `<div class="w-8 h-8 rounded-full bg-accent2 text-dark flex items-center justify-center font-bold order-2">You</div><div class="max-w-[80%] rounded-2xl rounded-tr-sm px-4 py-3 bg-accent2 text-dark shadow">${text}</div>`
+            : `<div class="w-8 h-8 rounded-full bg-accent text-dark flex items-center justify-center font-bold">AI</div><div class="max-w-[80%] rounded-2xl rounded-tl-sm px-4 py-3 bg-tertiary text-gray-100 shadow">${text}</div>`;
+          chatbotMessages.appendChild(row);
+          chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
+        };
+        const fallbackAnswer = (q) => {
+          const query = q.toLowerCase();
+          if (query.includes('contact') || query.includes('email')) return 'Contact Dr. Francis Jesmar P. Montalbo at francismontalbo@ieee.org or francisjesmar.montalbo@g.batstate-u.edu.ph.';
+          if (query.includes('scholar') || query.includes('scopus') || query.includes('h-index')) return 'Profiles: Google Scholar (user=PV8dJDkAAAAJ) and Scopus (authorId=57221928564).';
+          return 'Thanks for your question. The assistant is in fallback mode right now; please try again in a few seconds for full live responses.';
+        };
+        const sendFallbackMessage = () => {
+          const q = chatbotInput.value.trim();
+          if (!q) return;
+          addFallbackBubble(q, 'user');
+          chatbotInput.value = '';
+          addFallbackBubble(fallbackAnswer(q), 'assistant');
+        };
+        chatbotSend.addEventListener('click', sendFallbackMessage);
+        chatbotInput.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter') sendFallbackMessage();
+        });
+        chatbotSend.dataset.boundFallback = '1';
+      }
     </script>
-    <!-- Custom Script for publications -->
-    <!-- Load custom publications script with defer to ensure DOM is parsed before execution -->
+    <!-- Modular scripts -->
+    <script src="js/data.js" defer></script>
     <script src="js/script.js" defer></script>
+    <script src="js/chatbot.js" defer></script>
   </body>
 </html>

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -1,0 +1,230 @@
+// Chatbot module
+
+const { journalData, conferenceData, chapterData, newsData, profileContext } = window.SiteData || {};
+
+function initializeChatbot() {
+  const messages = document.getElementById('chatbot-messages');
+  const input = document.getElementById('chatbot-input');
+  const send = document.getElementById('chatbot-send');
+  const chips = document.querySelectorAll('.chatbot-chip');
+  const fab = document.getElementById('chatbot-fab');
+  const widget = document.getElementById('chatbot-widget');
+  const closeBtn = document.getElementById('chatbot-close');
+  const status = document.getElementById('chatbot-status');
+  if (!messages || !input || !send || !fab || !widget) return;
+  const statusEl = status || { textContent: '' };
+
+  const allWorks = [
+    ...journalData.map((w) => ({ ...w, type: 'Journal' })),
+    ...conferenceData.map((w) => ({ ...w, type: 'Conference' })),
+    ...chapterData.map((w) => ({ ...w, type: 'Chapter' }))
+  ];
+  const ragCorpus = [
+    ...journalData.map((item) => ({
+      type: 'journal',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.journal || ''} ${item.doi || ''}`,
+      payload: `${item.year || ''} | Journal | ${item.title || ''}${item.journal ? ` (${item.journal})` : ''}`
+    })),
+    ...conferenceData.map((item) => ({
+      type: 'conference',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.venue || ''} ${item.doi || ''}`,
+      payload: `${item.year || ''} | Conference | ${item.title || ''}${item.venue ? ` (${item.venue})` : ''}`
+    })),
+    ...chapterData.map((item) => ({
+      type: 'chapter',
+      title: item.title || '',
+      text: `${item.year || ''} ${item.authors || ''} ${item.title || ''} ${item.book || ''}`,
+      payload: `${item.year || ''} | Chapter | ${item.title || ''}${item.book ? ` (${item.book})` : ''}`
+    })),
+    ...newsData.map((item) => ({
+      type: 'news',
+      title: item.title || '',
+      text: `${item.date || ''} ${item.title || ''} ${item.summary || ''} ${(item.tags || []).join(' ')}`,
+      payload: `${item.date || ''} | News | ${item.title || ''} — ${item.summary || ''}`
+    }))
+  ];
+
+  function tokenize(text) {
+    return (text || '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((t) => t.length > 2);
+  }
+
+  function retrieveContext(query, limit = 8) {
+    const qTokens = tokenize(query);
+    const qSet = new Set(qTokens);
+    if (!qSet.size) return [];
+    const scored = ragCorpus.map((doc) => {
+      const tokens = tokenize(doc.text);
+      let score = 0;
+      tokens.forEach((token) => {
+        if (qSet.has(token)) score += 1;
+      });
+      if (qTokens.some((t) => (doc.title || '').toLowerCase().includes(t))) score += 3;
+      if (doc.type === 'news' && qTokens.some((t) => ['news', 'award', 'recognition', 'feature'].includes(t))) score += 2;
+      return { ...doc, score };
+    }).filter((doc) => doc.score > 0);
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit).map((doc) => doc.payload);
+  }
+
+  function addBubble(text, role = 'assistant') {
+    const row = document.createElement('div');
+    row.className = `flex items-start gap-2 ${role === 'user' ? 'justify-end' : ''}`;
+    const avatar = document.createElement('div');
+    avatar.className = `w-8 h-8 rounded-full flex items-center justify-center font-bold ${role === 'user' ? 'bg-accent2 text-dark order-2' : 'bg-accent text-dark'}`;
+    avatar.textContent = role === 'user' ? 'You' : 'AI';
+    const bubble = document.createElement('div');
+    bubble.className = role === 'user'
+      ? 'max-w-[80%] rounded-2xl rounded-tr-sm px-4 py-3 bg-accent2 text-dark shadow'
+      : 'max-w-[80%] rounded-2xl rounded-tl-sm px-4 py-3 bg-tertiary text-gray-100 shadow';
+    bubble.textContent = text;
+    row.appendChild(avatar);
+    row.appendChild(bubble);
+    messages.appendChild(row);
+    messages.scrollTop = messages.scrollHeight;
+    return bubble;
+  }
+
+  async function callLLM(messagesPayload) {
+    const prompt = messagesPayload.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n\n');
+    const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(prompt)}`);
+    if (!response.ok) {
+      throw new Error(`LLM request failed (${response.status})`);
+    }
+    return (await response.text()).trim();
+  }
+
+  function buildLocalFallback(question, retrieved) {
+    const q = (question || '').toLowerCase();
+    if (q.includes('contact') || q.includes('email') || q.includes('reach')) {
+      return 'You can contact Dr. Francis Jesmar P. Montalbo via francismontalbo@ieee.org and francisjesmar.montalbo@g.batstate-u.edu.ph. Profiles: Google Scholar, Scopus, ORCID, LinkedIn, and ResearchGate are available on this page.';
+    }
+    if (q.includes('h-index') || q.includes('h index') || q.includes('citation') || q.includes('scopus') || q.includes('scholar')) {
+      return 'For the latest metrics, please check the official profiles directly: Google Scholar (user=PV8dJDkAAAAJ) and Scopus (authorId=57221928564).';
+    }
+    if (retrieved && retrieved.length) {
+      return `Based on available on-page data, the most relevant information is:\n• ${retrieved.slice(0, 4).join('\n• ')}`;
+    }
+    return 'I’m currently unable to reach the live model. Please try again in a moment, or ask about publications, recognitions, contact details, or profiles shown on this page.';
+  }
+
+  var chatHistory = window.__francisChatHistory || [];
+  window.__francisChatHistory = chatHistory;
+  const liveMetricsTriggers = ['h-index', 'h index', 'citations', 'google scholar', 'scopus', 'metrics'];
+
+  async function fetchLiveMetricsSnapshot() {
+    const scholarUrl = 'https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en';
+    const scopusUrl = 'https://www.scopus.com/authid/detail.uri?authorId=57221928564';
+    const [scholarText, scopusText] = await Promise.all([
+      fetch(`https://r.jina.ai/http://${scholarUrl.replace(/^https?:\/\//, '')}`).then((r) => r.text()),
+      fetch(`https://r.jina.ai/http://${scopusUrl.replace(/^https?:\/\//, '')}`).then((r) => r.text())
+    ]);
+    const hIndexPatterns = [/h-index[^0-9]{0,20}(\d{1,3})/i, /h index[^0-9]{0,20}(\d{1,3})/i];
+    const citePatterns = [/citations[^0-9]{0,20}(\d{1,7})/i, /cited by[^0-9]{0,20}(\d{1,7})/i];
+    const extract = (text, patterns) => {
+      for (const p of patterns) {
+        const m = text.match(p);
+        if (m && m[1]) return m[1];
+      }
+      return null;
+    };
+    return {
+      scholarH: extract(scholarText, hIndexPatterns),
+      scholarCitations: extract(scholarText, citePatterns),
+      scopusH: extract(scopusText, hIndexPatterns)
+    };
+  }
+
+  async function ask() {
+    const question = input.value.trim();
+    if (!question) return;
+    addBubble(question, 'user');
+    input.value = '';
+    const thinkingBubble = addBubble('Thinking…');
+    send.disabled = true;
+    try {
+      const qLower = question.toLowerCase();
+      if (liveMetricsTriggers.some((t) => qLower.includes(t))) {
+        statusEl.textContent = 'Checking live metrics...';
+        try {
+          const live = await fetchLiveMetricsSnapshot();
+          const metricsReply = `Latest live snapshot I can retrieve right now:\n• Google Scholar h-index: ${live.scholarH || 'not detected'}\n• Google Scholar citations: ${live.scholarCitations || 'not detected'}\n• Scopus h-index: ${live.scopusH || 'not detected'}\n\nOfficial links:\n• Google Scholar: https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en\n• Scopus: https://www.scopus.com/authid/detail.uri?authorId=57221928564`;
+          thinkingBubble.textContent = metricsReply;
+          chatHistory.push({ role: 'assistant', content: metricsReply });
+          statusEl.textContent = 'Online mode enabled.';
+          return;
+        } catch (metricError) {
+          statusEl.textContent = 'Live metrics fetch failed; answering with known links.';
+        }
+      }
+      const retrieved = retrieveContext(question, 10);
+      const grounding = `PROFILE:\n${profileContext}\n\nRETRIEVED_CONTEXT:\n${retrieved.length ? retrieved.join('\n') : 'No highly relevant matches found.'}`;
+      chatHistory.push({ role: 'user', content: question });
+      const payload = [
+        {
+          role: 'system',
+          content: `You are Francis AI, a modern assistant for this portfolio website.
+Prioritize accuracy and clarity.
+Use RETRIEVED_CONTEXT first when answering profile-related queries.
+If context is insufficient, explicitly say so instead of inventing details.
+${grounding}`
+        },
+        ...chatHistory.slice(-8)
+      ];
+      statusEl.textContent = 'Thinking...';
+      const text = await callLLM(payload);
+      const finalText = text || buildLocalFallback(question, retrieved);
+      thinkingBubble.textContent = finalText;
+      chatHistory.push({ role: 'assistant', content: finalText });
+      statusEl.textContent = 'Online mode enabled.';
+    } catch (err) {
+      const retrieved = retrieveContext(question, 10);
+      thinkingBubble.textContent = buildLocalFallback(question, retrieved);
+      statusEl.textContent = 'Live model unreachable; fallback mode active.';
+    } finally {
+      send.disabled = false;
+    }
+  }
+
+  const openWidget = () => {
+    widget.classList.remove('hidden');
+    widget.style.display = 'block';
+    fab.classList.add('hidden');
+    fab.setAttribute('aria-expanded', 'true');
+    if (!messages.dataset.booted) {
+      addBubble('Hi! I’m Francis AI. Ask anything—especially about Francis, his works, and achievements.');
+      messages.dataset.booted = '1';
+    }
+  };
+  const closeWidget = () => {
+    widget.classList.add('hidden');
+    widget.style.display = '';
+    fab.classList.remove('hidden');
+    fab.setAttribute('aria-expanded', 'false');
+  };
+
+  fab.addEventListener('click', openWidget);
+  fab.addEventListener('pointerdown', openWidget);
+  if (closeBtn) closeBtn.addEventListener('click', closeWidget);
+
+  send.addEventListener('click', ask);
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') ask();
+  });
+  chips.forEach((chip) => {
+    chip.addEventListener('click', () => {
+      input.value = chip.dataset.question || '';
+      ask();
+    });
+  });
+}
+
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    try { initializeChatbot(); } catch (e) { console.error('Chatbot init failed:', e); }
+  });
+} else {
+  try { initializeChatbot(); } catch (e) { console.error('Chatbot init failed:', e); }
+}

--- a/js/data.js
+++ b/js/data.js
@@ -1,0 +1,419 @@
+// Centralized site data for publications, news, and profile context.
+
+const journalData = [
+  {
+    year: 2026,
+    authors: "FJP Montalbo",
+    title:
+      "MHADFormer: A Cost-Efficient Multiscale Hybrid Transformer Mixer Model for Automating Alzheimer’s Disease Diagnosis from MRI Scans",
+    journal: "Applied Soft Computing",
+    volume: "114624",
+    date: "2026",
+    doi: "10.1016/j.asoc.2026.114624",
+    doiUrl: "https://doi.org/10.1016/j.asoc.2026.114624",
+    codeUrl: "https://github.com/francismontalbo/mhadformer",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2025,
+    authors: "FJP Montalbo",
+    title:
+      "TUMbRAIN: A transformer with a unified mobile residual attention inverted network for diagnosing brain tumors from magnetic resonance scans",
+    journal: "Neurocomputing",
+    volume: "611",
+    date: "January 1, 2025",
+    doi: "10.1016/j.neucom.2024.128583",
+    doiUrl: "https://doi.org/10.1016/j.neucom.2024.128583",
+    codeUrl: "https://github.com/francismontalbo/tumbrain",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2024,
+    authors: "FJP Montalbo",
+    title:
+      "DySARNet: a lightweight self‑attention deep learning model for diagnosing dysarthria from speech recordings",
+    journal: "Multimedia Tools and Applications",
+    date: "August 31, 2024",
+    doi: "10.1007/s11042-024-20053-w",
+    doiUrl: "https://doi.org/10.1007/s11042-024-20053-w",
+    publisher: "Springer"
+  },
+  {
+    year: 2024,
+    authors: "ALP De Ocampo, FJP Montalbo",
+    title:
+      "A Multi‑Vision Monitoring Framework for Simultaneous Real‑Time Unmanned Aerial Monitoring of Farmer Activity and Crop Health",
+    journal: "Smart Agricultural Technology",
+    date: "May 16, 2024",
+    doi: "10.1016/j.atech.2024.100466",
+    doiUrl: "https://doi.org/10.1016/j.atech.2024.100466",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2024,
+    authors: "RD Maalihan, JCV Aggari, AS Alon, RB Latayan, FJP Montalbo, AD Javier",
+    title:
+      "On the optimized fused filament fabrication of polylactic acid using multiresponse central composite design and desirability function algorithm",
+    journal: "Journal of Process Mechanical Engineering",
+    date: "April 24, 2024",
+    doi: "10.1177/09544089241247454",
+    doiUrl: "https://doi.org/10.1177/09544089241247454",
+    publisher: "SAGE"
+  },
+  {
+    year: 2024,
+    authors: "FJP Montalbo",
+    title:
+      "S3AR U‑Net: A Separable Squeezed Similarity Attention‑gated Residual U‑Net for Glottis Segmentation",
+    journal: "Biomedical Signal Processing and Control",
+    date: "February 21, 2024",
+    doi: "10.1016/j.bspc.2024.106047",
+    doiUrl: "https://doi.org/10.1016/j.bspc.2024.106047",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2023,
+    authors: "FJP Montalbo",
+    title:
+      "Automating Mosquito Taxonomy by Compressing and Enhancing a Feature Fused EfficientNet with Knowledge Distillation and a Novel Residual Skip Block",
+    journal: "MethodsX",
+    date: "February 14, 2023",
+    doi: "10.1016/j.mex.2023.102072",
+    doiUrl: "https://doi.org/10.1016/j.mex.2023.102072",
+    publisher: "Elsevier"
+  },
+  // 2022 entries
+  {
+    year: 2022,
+    authors: "FJP Montalbo",
+    title:
+      "Machine‑based Mosquito Taxonomy with a Lightweight Network‑fused Efficient Dual ConvNet with Residual Learning and Knowledge Distillation",
+    journal: "Applied Soft Computing",
+    date: "December 16, 2022",
+    doi: "10.1016/j.asoc.2022.109913",
+    doiUrl: "https://doi.org/10.1016/j.asoc.2022.109913",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2022,
+    authors: "FJP Montalbo",
+    title:
+      "Fusing Compressed Deep ConvNets with a Self‑Normalizing Residual Block and Alpha Dropout for a Cost‑Efficient Classification and Diagnosis of Gastrointestinal Tract Diseases",
+    journal: "MethodsX",
+    date: "November 2022",
+    doi: "10.1016/j.mex.2022.101925",
+    doiUrl: "https://doi.org/10.1016/j.mex.2022.101925",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2022,
+    authors:
+      "R. G. Kerry, FJP Montalbo, R. Das, S. Patra, G. P. Mahaptra, G. K. Maurya, V. Nayak, A. B. Jena, K. E. Ukhurebor, R. C. Jena, S. Gouda, S. Majhi, J. R. Rout",
+    title: "An overview of remote monitoring methods in biodiversity conservation",
+    journal: "Environmental Science and Pollution Research",
+    date: "2022",
+    doi: "10.1007/s11356-022-23242-y",
+    doiUrl: "https://doi.org/10.1007/s11356-022-23242-y",
+    publisher: "Springer"
+  },
+  {
+    year: 2022,
+    authors:
+      "N. Z. Rashed, S. K. H. Ahammad, M. G. Daher, S. H. Zyoud, V. Sorathiya, FJP Montalbo, S. Asaduzzaman, H. Rehana, A. Zuhayer",
+    title:
+      "Various transmission codes for the control of bit error rate in both optical wired and wireless communication channels",
+    journal: "Journal of Optical Communications",
+    date: "July 18, 2022",
+    doi: "10.1515/joc-2022-0044",
+    doiUrl: "https://doi.org/10.1515/joc-2022-0044",
+    publisher: "De Gruyter"
+  },
+  {
+    year: 2022,
+    authors:
+      "N. Z. Rashed, M. G. Daher, S. K. H. Ahammad, FJP Montalbo, V. Sorathiya, S. Asaduzzaman, H. Rehana, A. Zuhayer",
+    title:
+      "Non return to zero line coding with suppressed carrier in FSO transceiver systems under light rain conditions",
+    journal: "Journal of Optical Communications",
+    date: "July 13, 2022",
+    doi: "10.1515/joc-2022-0039",
+    doiUrl: "https://doi.org/10.1515/joc-2022-0039",
+    publisher: "De Gruyter"
+  },
+  {
+    year: 2022,
+    authors: "FJP Montalbo",
+    title:
+      "Diagnosing Gastrointestinal Diseases from Endoscopy Images through a Multi‑Fused CNN with Auxiliary Layers, Alpha Dropouts, and a Fusion Residual Block",
+    journal: "Biomedical Signal Processing and Control",
+    volume: "76",
+    date: "July 2022",
+    doi: "10.1016/j.bspc.2022.103683",
+    doiUrl: "https://doi.org/10.1016/j.bspc.2022.103683",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2022,
+    authors: "FJP Montalbo",
+    title:
+      "Truncating Fined‑Tuned Vision‑Based Models to Lightweight Deployable Diagnostic Tools for SARS‑CoV‑2 Infected Chest X‑Rays and CT‑Scans",
+    journal: "Multimedia Tools and Applications",
+    date: "2022",
+    doi: "10.1007/s11042-022-12484-0",
+    doiUrl: "https://doi.org/10.1007/s11042-022-12484-0",
+    publisher: "Springer"
+  },
+  {
+    year: 2022,
+    authors: "FJP Montalbo",
+    title:
+      "Automated Diagnosis of Diverse Coffee Leaf Images through a Stage‑Wise Aggregated Triple Deep Convolutional Neural Network",
+    journal: "Machine Vision and Applications",
+    volume: "33, no. 1, pp. 1–22",
+    date: "2022",
+    doi: "10.1007/s00138-022-01277-y",
+    doiUrl: "https://doi.org/10.1007/s00138-022-01277-y",
+    publisher: "Springer"
+  },
+  // 2021 entries
+  {
+    year: 2021,
+    authors: "FJP Montalbo",
+    title:
+      "Truncating a Densely Connected Convolutional Neural Network with Partial Layer Freezing and Feature Fusion for Diagnosing COVID‑19 from Chest X‑Rays",
+    journal: "MethodsX",
+    volume: "8, 101408",
+    date: "2021",
+    doi: "10.1016/j.mex.2021.101408",
+    doiUrl: "https://doi.org/10.1016/j.mex.2021.101408",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2021,
+    authors: "FJP Montalbo",
+    title:
+      "Diagnosing Covid‑19 Chest X‑Rays with a Lightweight Truncated DenseNet with Partial Layer Freezing and Feature Fusion",
+    journal: "Biomedical Signal Processing and Control",
+    volume: "68, 102583",
+    date: "2021",
+    doi: "10.1016/j.bspc.2021.102583",
+    doiUrl: "https://doi.org/10.1016/j.bspc.2021.102583",
+    publisher: "Elsevier"
+  },
+  {
+    year: 2021,
+    authors: "FJP Montalbo, A. S. Alon",
+    title:
+      "Empirical Analysis of a Fine‑Tuned Deep Convolutional Model in Classifying and Detecting Malaria Parasites from Blood Smears",
+    journal: "KSII Transactions on Internet & Information Systems (TIIS)",
+    volume: "15, no. 1, pp. 147–165",
+    date: "2021",
+    doi: "10.3837/tiis.2021.01.009",
+    doiUrl: "https://doi.org/10.3837/tiis.2021.01.009",
+    publisher: "KSII"
+  },
+  // 2020 entries
+  {
+    year: 2020,
+    authors: "FJP Montalbo",
+    title:
+      "A Computer‑Aided Diagnosis of Brain Tumors Using a Fine‑Tuned YOLO‑based Model with Transfer Learning",
+    journal: "KSII Transactions on Internet & Information Systems (TIIS)",
+    volume: "14, no. 12, pp. 4816–4834",
+    date: "2020",
+    doi: "10.3837/tiis.2020.12.011",
+    doiUrl: "https://doi.org/10.3837/tiis.2020.12.011",
+    publisher: "KSII"
+  },
+  {
+    year: 2020,
+    authors: "FJP Montalbo, A. A. Hernandez",
+    title:
+      "Classifying Barako coffee leaf diseases using deep convolutional models",
+    journal: "International Journal of Advances in Intelligent Informatics (IJAIN)",
+    volume: "6, no. 2, p. 197",
+    date: "2020",
+    doi: "10.26555/ijain.v6i2.495",
+    doiUrl: "https://doi.org/10.26555/ijain.v6i2.495",
+    publisher: "IJAIN"
+  }
+];
+
+const conferenceData = [
+  {
+    year: 2024,
+    authors: "FJP Montalbo, LP Palad, RL Castillo, KI Marasigan, ALP De Ocampo",
+    title:
+      "CT Scan Liver and Liver Tumor 2D Segmentation: A Deep Learning Review and Empirical Analysis",
+    venue: "2024 IEEE 12th Conference on Systems, Process & Control (ICSPC)",
+    location: "Malacca, Malaysia",
+    pages: "pp. 35–40",
+    doi: "10.1109/ICSPC63060.2024.10862188",
+    doiUrl: "https://doi.org/10.1109/ICSPC63060.2024.10862188",
+    publisher: "IEEE"
+  },
+  {
+    year: 2024,
+    authors: "ALP De Ocampo, AS Alon, FJP Montalbo, JR Macalisang, JCV Aggari",
+    title:
+      "Intelligent Control for Automated Fish Feeding System in an Aquaponic Environment",
+    venue:
+      "2024 7th International Conference on Informatics and Computational Sciences (ICICoS)",
+    location: "Semarang, Indonesia",
+    pages: "pp. 273–278",
+    doi: "10.1109/ICICoS62600.2024.10636920",
+    doiUrl: "https://doi.org/10.1109/ICICoS62600.2024.10636920",
+    publisher: "IEEE"
+  },
+  {
+    year: 2023,
+    authors: "FJP Montalbo",
+    title:
+      "Performance Analysis of Lightweight Vision Transformers and Deep Convolutional Neural Networks in Detecting Brain Tumors in MRI Scans: An Empirical Approach",
+    venue:
+      "Proceedings of the 2023 8th International Conference on Biomedical Imaging, Signal Processing",
+    doi: "10.1145/3634875.3634878",
+    doiUrl: "https://doi.org/10.1145/3634875.3634878",
+    publisher: "ACM"
+  },
+  {
+    year: 2021,
+    authors: "Francis Jesmar Montalbo; Erwin Enriquez",
+    title:
+      "An IoT Smart Lighting System for University Classrooms",
+    venue: "IEEE International Conference on IoT Systems for Education",
+    location: "Philippines",
+    pages: "",
+    doi: "",
+    doiUrl: "",
+    publisher: "IEEE"
+  },
+  {
+    year: 2020,
+    authors: "–",
+    title: "System for University Classrooms",
+    venue: "2020 International Symposium on Educational Technology (ISET)",
+    location: "Bangkok, Thailand",
+    pages: "pp. 3–7",
+    doi: "10.1109/ISET49818.2020.00011",
+    doiUrl: "https://doi.org/10.1109/ISET49818.2020.00011",
+    publisher: "IEEE"
+  },
+  {
+    year: 2020,
+    authors: "FJP Montalbo, A. A. Hernandez",
+    title:
+      "An Optimized Classification Model for Coffea Liberica Disease using Deep Convolutional Neural Networks",
+    venue:
+      "2020 16th IEEE International Colloquium on Signal Processing & Its Applications (CSPA)",
+    location: "Langkawi, Malaysia",
+    pages: "pp. 213–218",
+    doi: "10.1109/CSPA48992.2020.9068683",
+    doiUrl: "https://doi.org/10.1109/CSPA48992.2020.9068683",
+    publisher: "IEEE"
+  },
+  {
+    year: 2019,
+    authors: "FJP Montalbo, DPY Barfeh",
+    title:
+      "Classification of Stenography using Convolutional Neural Networks and Canny Edge Detection Algorithm",
+    venue:
+      "2019 International Conference on Computational Intelligence and Knowledge Economy (ICCIKE)",
+    location: "Dubai, United Arab Emirates",
+    pages: "pp. 305–310",
+    doi: "10.1109/ICCIKE47802.2019.9004359",
+    doiUrl: "https://doi.org/10.1109/ICCIKE47802.2019.9004359",
+    publisher: "IEEE"
+  },
+  {
+    year: 2019,
+    authors: "FJP Montalbo, A. A. Hernandez",
+    title:
+      "Classification of Fish Species with Augmented Data using Deep Convolutional Neural Network",
+    venue: "2019 IEEE 9th International Conference on System Engineering and Technology (ICSET)",
+    location: "Shah Alam, Malaysia",
+    pages: "pp. 396–401",
+    doi: "10.1109/ICSEngT.2019.8906433",
+    doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906433",
+    publisher: "IEEE"
+  },
+  {
+    year: 2019,
+    authors: "FJP Montalbo, E. D. Festijo",
+    title:
+      "Comparative Analysis of Ensemble Learning Methods in Classifying Network Intrusions",
+    venue: "2019 IEEE 9th International Conference on System Engineering and Technology (ICSET)",
+    location: "Shah Alam, Malaysia",
+    pages: "pp. 431–436",
+    doi: "10.1109/ICSEngT.2019.8906310",
+    doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906310",
+    publisher: "IEEE"
+  }
+];
+
+const chapterData = [
+  {
+    authors:
+      "Kingsley Eghonghon Ukhurebor, Uyiosa Osagie Aigbe, Joseph Onyeka Emegha, Lucky Evbuomwan, Bamikole Olaleye Akinsehinde, Olusoji Anthony Ayeleso, Rout George Kerry, Benedict Okundaye, Atala Bihari Jena, Francis Jesmar P Montalbo, Grace Jokthan, Aizebeoje Balogun Vincent, Ahmed El Nemr",
+    title: "Environmental Applications of Magnetic Sorbents",
+    book: "Environmental Applications of Magnetic Sorbents",
+    year: "2024",
+    pages: "pp. 8-1 – 8-15",
+    publisher: "IOP Publishing",
+    isbn: "978-0-7503-5909-2",
+    url: "https://iopscience.iop.org/book/edit/978-0-7503-5909-2"
+  },
+  {
+    authors: "FJP Montalbo et al.",
+    title:
+      "The challenges of, and perspectives on adsorption applications for environmental sustainability",
+    book: "Adsorption Applications for Environmental Sustainability",
+    year: "2023",
+    publisher: "IOP Publishing",
+    isbn: "978-0-7503-5598-8",
+    url: "https://iopscience.iop.org/book/edit/978-0-7503-5598-8.pdf"
+  }
+];
+
+// News posts (easy content management: add newest items here).
+const newsData = [
+  {
+    date: "2026-05-05",
+    title: "National Spotlight: Recognized in OneNews Stanford Scientists Feature",
+    summary: "Dr. Francis Jesmar P. Montalbo is recognized in OneNews’ Stanford scientists coverage, reinforcing his position among high-impact Filipino researchers with internationally visible contributions in artificial intelligence, biomedical signal processing, and medical imaging innovation.",
+    expandedSummary: "The OneNews feature strengthens the public profile of Dr. Francis Jesmar P. Montalbo as a globally competitive AI research scientist from the Philippines. His inclusion in the Stanford scientists context highlights sustained excellence, international research visibility, and trusted expertise—key indicators for universities, industry partners, and institutions seeking strategic collaboration in advanced AI and biomedical technologies.",
+    tags: ["media-feature", "stanford-top-2%", "research-impact"],
+    link: "https://www.onenews.ph/articles/phl-has-fewest-scientists-in-asean-stanford-list",
+    linkLabel: "Read feature",
+    image: "assets/img/achievements.jpg",
+    imageAlt: "Dr. Francis Jesmar P. Montalbo achievements and recognitions photo",
+    pinned: true
+  },
+  {
+    date: "2023-10-22",
+    title: "ICBSP 2023: Selected as One of the Best Presenters",
+    summary: "Dr. Francis Jesmar P. Montalbo was selected as one of the Best Presenters at ICBSP 2023 in Singapore, underscoring his research excellence and international leadership in biomedical imaging, signal processing, and applied artificial intelligence.",
+    expandedSummary: "This international conference distinction positions Dr. Francis Jesmar P. Montalbo among top-performing global presenters in a competitive scientific forum. With ICBSP proceedings published by ACM and recognized in major indexing ecosystems, this achievement amplifies his authority, credibility, and strategic value for global research partnerships, keynote engagements, and cross-border innovation programs.",
+    tags: ["best-presenter", "international-conference", "ai-research"],
+    link: "https://www.icbsp.org/icbsp2023.html",
+    linkLabel: "Conference page",
+    image: "assets/img/experience.jpg",
+    imageAlt: "Dr. Francis Jesmar P. Montalbo international conference and research experience photo",
+    pinned: true
+  }
+];
+
+const profileContext = `
+Name: Dr. Francis Jesmar P. Montalbo
+Roles: Associate Professor, Research Scientist, AI & Deep Learning Specialist, Software Engineer
+Affiliation: Batangas State University
+Research: medical imaging AI, deep learning, biomedical signal processing, computer vision
+Education: Doctorate in Information Technology (Technological Institute of the Philippines-Manila)
+Selected Achievements: OneNews Stanford scientists feature; ICBSP 2023 best presenter
+Contact Emails: francismontalbo@ieee.org; francisjesmar.montalbo@g.batstate-u.edu.ph
+Profiles: Scopus https://www.scopus.com/authid/detail.uri?authorId=57221928564 | Google Scholar https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en | ORCID https://orcid.org/0000-0002-1493-5080 | LinkedIn https://www.linkedin.com/in/sirjmmontalbo/ | ResearchGate https://www.researchgate.net/profile/Francis_Jesmar_Montalbo
+When asked for contact, give exact email addresses and links above.
+`;
+
+
+window.SiteData = { journalData, conferenceData, chapterData, newsData, profileContext };

--- a/js/script.js
+++ b/js/script.js
@@ -8,412 +8,7 @@
 // properties such as volume, pages, location, doi, doiUrl, codeUrl,
 // publisher, access ("open" or "closed"), and pubmedUrl (link to PubMed if available).
 
-const journalData = [
-  {
-    year: 2026,
-    authors: "FJP Montalbo",
-    title:
-      "MHADFormer: A Cost-Efficient Multiscale Hybrid Transformer Mixer Model for Automating Alzheimer’s Disease Diagnosis from MRI Scans",
-    journal: "Applied Soft Computing",
-    volume: "114624",
-    date: "2026",
-    doi: "10.1016/j.asoc.2026.114624",
-    doiUrl: "https://doi.org/10.1016/j.asoc.2026.114624",
-    codeUrl: "https://github.com/francismontalbo/mhadformer",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2025,
-    authors: "FJP Montalbo",
-    title:
-      "TUMbRAIN: A transformer with a unified mobile residual attention inverted network for diagnosing brain tumors from magnetic resonance scans",
-    journal: "Neurocomputing",
-    volume: "611",
-    date: "January 1, 2025",
-    doi: "10.1016/j.neucom.2024.128583",
-    doiUrl: "https://doi.org/10.1016/j.neucom.2024.128583",
-    codeUrl: "https://github.com/francismontalbo/tumbrain",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2024,
-    authors: "FJP Montalbo",
-    title:
-      "DySARNet: a lightweight self‑attention deep learning model for diagnosing dysarthria from speech recordings",
-    journal: "Multimedia Tools and Applications",
-    date: "August 31, 2024",
-    doi: "10.1007/s11042-024-20053-w",
-    doiUrl: "https://doi.org/10.1007/s11042-024-20053-w",
-    publisher: "Springer"
-  },
-  {
-    year: 2024,
-    authors: "ALP De Ocampo, FJP Montalbo",
-    title:
-      "A Multi‑Vision Monitoring Framework for Simultaneous Real‑Time Unmanned Aerial Monitoring of Farmer Activity and Crop Health",
-    journal: "Smart Agricultural Technology",
-    date: "May 16, 2024",
-    doi: "10.1016/j.atech.2024.100466",
-    doiUrl: "https://doi.org/10.1016/j.atech.2024.100466",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2024,
-    authors: "RD Maalihan, JCV Aggari, AS Alon, RB Latayan, FJP Montalbo, AD Javier",
-    title:
-      "On the optimized fused filament fabrication of polylactic acid using multiresponse central composite design and desirability function algorithm",
-    journal: "Journal of Process Mechanical Engineering",
-    date: "April 24, 2024",
-    doi: "10.1177/09544089241247454",
-    doiUrl: "https://doi.org/10.1177/09544089241247454",
-    publisher: "SAGE"
-  },
-  {
-    year: 2024,
-    authors: "FJP Montalbo",
-    title:
-      "S3AR U‑Net: A Separable Squeezed Similarity Attention‑gated Residual U‑Net for Glottis Segmentation",
-    journal: "Biomedical Signal Processing and Control",
-    date: "February 21, 2024",
-    doi: "10.1016/j.bspc.2024.106047",
-    doiUrl: "https://doi.org/10.1016/j.bspc.2024.106047",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2023,
-    authors: "FJP Montalbo",
-    title:
-      "Automating Mosquito Taxonomy by Compressing and Enhancing a Feature Fused EfficientNet with Knowledge Distillation and a Novel Residual Skip Block",
-    journal: "MethodsX",
-    date: "February 14, 2023",
-    doi: "10.1016/j.mex.2023.102072",
-    doiUrl: "https://doi.org/10.1016/j.mex.2023.102072",
-    publisher: "Elsevier"
-  },
-  // 2022 entries
-  {
-    year: 2022,
-    authors: "FJP Montalbo",
-    title:
-      "Machine‑based Mosquito Taxonomy with a Lightweight Network‑fused Efficient Dual ConvNet with Residual Learning and Knowledge Distillation",
-    journal: "Applied Soft Computing",
-    date: "December 16, 2022",
-    doi: "10.1016/j.asoc.2022.109913",
-    doiUrl: "https://doi.org/10.1016/j.asoc.2022.109913",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2022,
-    authors: "FJP Montalbo",
-    title:
-      "Fusing Compressed Deep ConvNets with a Self‑Normalizing Residual Block and Alpha Dropout for a Cost‑Efficient Classification and Diagnosis of Gastrointestinal Tract Diseases",
-    journal: "MethodsX",
-    date: "November 2022",
-    doi: "10.1016/j.mex.2022.101925",
-    doiUrl: "https://doi.org/10.1016/j.mex.2022.101925",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2022,
-    authors:
-      "R. G. Kerry, FJP Montalbo, R. Das, S. Patra, G. P. Mahaptra, G. K. Maurya, V. Nayak, A. B. Jena, K. E. Ukhurebor, R. C. Jena, S. Gouda, S. Majhi, J. R. Rout",
-    title: "An overview of remote monitoring methods in biodiversity conservation",
-    journal: "Environmental Science and Pollution Research",
-    date: "2022",
-    doi: "10.1007/s11356-022-23242-y",
-    doiUrl: "https://doi.org/10.1007/s11356-022-23242-y",
-    publisher: "Springer"
-  },
-  {
-    year: 2022,
-    authors:
-      "N. Z. Rashed, S. K. H. Ahammad, M. G. Daher, S. H. Zyoud, V. Sorathiya, FJP Montalbo, S. Asaduzzaman, H. Rehana, A. Zuhayer",
-    title:
-      "Various transmission codes for the control of bit error rate in both optical wired and wireless communication channels",
-    journal: "Journal of Optical Communications",
-    date: "July 18, 2022",
-    doi: "10.1515/joc-2022-0044",
-    doiUrl: "https://doi.org/10.1515/joc-2022-0044",
-    publisher: "De Gruyter"
-  },
-  {
-    year: 2022,
-    authors:
-      "N. Z. Rashed, M. G. Daher, S. K. H. Ahammad, FJP Montalbo, V. Sorathiya, S. Asaduzzaman, H. Rehana, A. Zuhayer",
-    title:
-      "Non return to zero line coding with suppressed carrier in FSO transceiver systems under light rain conditions",
-    journal: "Journal of Optical Communications",
-    date: "July 13, 2022",
-    doi: "10.1515/joc-2022-0039",
-    doiUrl: "https://doi.org/10.1515/joc-2022-0039",
-    publisher: "De Gruyter"
-  },
-  {
-    year: 2022,
-    authors: "FJP Montalbo",
-    title:
-      "Diagnosing Gastrointestinal Diseases from Endoscopy Images through a Multi‑Fused CNN with Auxiliary Layers, Alpha Dropouts, and a Fusion Residual Block",
-    journal: "Biomedical Signal Processing and Control",
-    volume: "76",
-    date: "July 2022",
-    doi: "10.1016/j.bspc.2022.103683",
-    doiUrl: "https://doi.org/10.1016/j.bspc.2022.103683",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2022,
-    authors: "FJP Montalbo",
-    title:
-      "Truncating Fined‑Tuned Vision‑Based Models to Lightweight Deployable Diagnostic Tools for SARS‑CoV‑2 Infected Chest X‑Rays and CT‑Scans",
-    journal: "Multimedia Tools and Applications",
-    date: "2022",
-    doi: "10.1007/s11042-022-12484-0",
-    doiUrl: "https://doi.org/10.1007/s11042-022-12484-0",
-    publisher: "Springer"
-  },
-  {
-    year: 2022,
-    authors: "FJP Montalbo",
-    title:
-      "Automated Diagnosis of Diverse Coffee Leaf Images through a Stage‑Wise Aggregated Triple Deep Convolutional Neural Network",
-    journal: "Machine Vision and Applications",
-    volume: "33, no. 1, pp. 1–22",
-    date: "2022",
-    doi: "10.1007/s00138-022-01277-y",
-    doiUrl: "https://doi.org/10.1007/s00138-022-01277-y",
-    publisher: "Springer"
-  },
-  // 2021 entries
-  {
-    year: 2021,
-    authors: "FJP Montalbo",
-    title:
-      "Truncating a Densely Connected Convolutional Neural Network with Partial Layer Freezing and Feature Fusion for Diagnosing COVID‑19 from Chest X‑Rays",
-    journal: "MethodsX",
-    volume: "8, 101408",
-    date: "2021",
-    doi: "10.1016/j.mex.2021.101408",
-    doiUrl: "https://doi.org/10.1016/j.mex.2021.101408",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2021,
-    authors: "FJP Montalbo",
-    title:
-      "Diagnosing Covid‑19 Chest X‑Rays with a Lightweight Truncated DenseNet with Partial Layer Freezing and Feature Fusion",
-    journal: "Biomedical Signal Processing and Control",
-    volume: "68, 102583",
-    date: "2021",
-    doi: "10.1016/j.bspc.2021.102583",
-    doiUrl: "https://doi.org/10.1016/j.bspc.2021.102583",
-    publisher: "Elsevier"
-  },
-  {
-    year: 2021,
-    authors: "FJP Montalbo, A. S. Alon",
-    title:
-      "Empirical Analysis of a Fine‑Tuned Deep Convolutional Model in Classifying and Detecting Malaria Parasites from Blood Smears",
-    journal: "KSII Transactions on Internet & Information Systems (TIIS)",
-    volume: "15, no. 1, pp. 147–165",
-    date: "2021",
-    doi: "10.3837/tiis.2021.01.009",
-    doiUrl: "https://doi.org/10.3837/tiis.2021.01.009",
-    publisher: "KSII"
-  },
-  // 2020 entries
-  {
-    year: 2020,
-    authors: "FJP Montalbo",
-    title:
-      "A Computer‑Aided Diagnosis of Brain Tumors Using a Fine‑Tuned YOLO‑based Model with Transfer Learning",
-    journal: "KSII Transactions on Internet & Information Systems (TIIS)",
-    volume: "14, no. 12, pp. 4816–4834",
-    date: "2020",
-    doi: "10.3837/tiis.2020.12.011",
-    doiUrl: "https://doi.org/10.3837/tiis.2020.12.011",
-    publisher: "KSII"
-  },
-  {
-    year: 2020,
-    authors: "FJP Montalbo, A. A. Hernandez",
-    title:
-      "Classifying Barako coffee leaf diseases using deep convolutional models",
-    journal: "International Journal of Advances in Intelligent Informatics (IJAIN)",
-    volume: "6, no. 2, p. 197",
-    date: "2020",
-    doi: "10.26555/ijain.v6i2.495",
-    doiUrl: "https://doi.org/10.26555/ijain.v6i2.495",
-    publisher: "IJAIN"
-  }
-];
-
-const conferenceData = [
-  {
-    year: 2024,
-    authors: "FJP Montalbo, LP Palad, RL Castillo, KI Marasigan, ALP De Ocampo",
-    title:
-      "CT Scan Liver and Liver Tumor 2D Segmentation: A Deep Learning Review and Empirical Analysis",
-    venue: "2024 IEEE 12th Conference on Systems, Process & Control (ICSPC)",
-    location: "Malacca, Malaysia",
-    pages: "pp. 35–40",
-    doi: "10.1109/ICSPC63060.2024.10862188",
-    doiUrl: "https://doi.org/10.1109/ICSPC63060.2024.10862188",
-    publisher: "IEEE"
-  },
-  {
-    year: 2024,
-    authors: "ALP De Ocampo, AS Alon, FJP Montalbo, JR Macalisang, JCV Aggari",
-    title:
-      "Intelligent Control for Automated Fish Feeding System in an Aquaponic Environment",
-    venue:
-      "2024 7th International Conference on Informatics and Computational Sciences (ICICoS)",
-    location: "Semarang, Indonesia",
-    pages: "pp. 273–278",
-    doi: "10.1109/ICICoS62600.2024.10636920",
-    doiUrl: "https://doi.org/10.1109/ICICoS62600.2024.10636920",
-    publisher: "IEEE"
-  },
-  {
-    year: 2023,
-    authors: "FJP Montalbo",
-    title:
-      "Performance Analysis of Lightweight Vision Transformers and Deep Convolutional Neural Networks in Detecting Brain Tumors in MRI Scans: An Empirical Approach",
-    venue:
-      "Proceedings of the 2023 8th International Conference on Biomedical Imaging, Signal Processing",
-    doi: "10.1145/3634875.3634878",
-    doiUrl: "https://doi.org/10.1145/3634875.3634878",
-    publisher: "ACM"
-  },
-  {
-    year: 2021,
-    authors: "Francis Jesmar Montalbo; Erwin Enriquez",
-    title:
-      "An IoT Smart Lighting System for University Classrooms",
-    venue: "IEEE International Conference on IoT Systems for Education",
-    location: "Philippines",
-    pages: "",
-    doi: "",
-    doiUrl: "",
-    publisher: "IEEE"
-  },
-  {
-    year: 2020,
-    authors: "–",
-    title: "System for University Classrooms",
-    venue: "2020 International Symposium on Educational Technology (ISET)",
-    location: "Bangkok, Thailand",
-    pages: "pp. 3–7",
-    doi: "10.1109/ISET49818.2020.00011",
-    doiUrl: "https://doi.org/10.1109/ISET49818.2020.00011",
-    publisher: "IEEE"
-  },
-  {
-    year: 2020,
-    authors: "FJP Montalbo, A. A. Hernandez",
-    title:
-      "An Optimized Classification Model for Coffea Liberica Disease using Deep Convolutional Neural Networks",
-    venue:
-      "2020 16th IEEE International Colloquium on Signal Processing & Its Applications (CSPA)",
-    location: "Langkawi, Malaysia",
-    pages: "pp. 213–218",
-    doi: "10.1109/CSPA48992.2020.9068683",
-    doiUrl: "https://doi.org/10.1109/CSPA48992.2020.9068683",
-    publisher: "IEEE"
-  },
-  {
-    year: 2019,
-    authors: "FJP Montalbo, DPY Barfeh",
-    title:
-      "Classification of Stenography using Convolutional Neural Networks and Canny Edge Detection Algorithm",
-    venue:
-      "2019 International Conference on Computational Intelligence and Knowledge Economy (ICCIKE)",
-    location: "Dubai, United Arab Emirates",
-    pages: "pp. 305–310",
-    doi: "10.1109/ICCIKE47802.2019.9004359",
-    doiUrl: "https://doi.org/10.1109/ICCIKE47802.2019.9004359",
-    publisher: "IEEE"
-  },
-  {
-    year: 2019,
-    authors: "FJP Montalbo, A. A. Hernandez",
-    title:
-      "Classification of Fish Species with Augmented Data using Deep Convolutional Neural Network",
-    venue: "2019 IEEE 9th International Conference on System Engineering and Technology (ICSET)",
-    location: "Shah Alam, Malaysia",
-    pages: "pp. 396–401",
-    doi: "10.1109/ICSEngT.2019.8906433",
-    doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906433",
-    publisher: "IEEE"
-  },
-  {
-    year: 2019,
-    authors: "FJP Montalbo, E. D. Festijo",
-    title:
-      "Comparative Analysis of Ensemble Learning Methods in Classifying Network Intrusions",
-    venue: "2019 IEEE 9th International Conference on System Engineering and Technology (ICSET)",
-    location: "Shah Alam, Malaysia",
-    pages: "pp. 431–436",
-    doi: "10.1109/ICSEngT.2019.8906310",
-    doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906310",
-    publisher: "IEEE"
-  }
-];
-
-const chapterData = [
-  {
-    authors:
-      "Kingsley Eghonghon Ukhurebor, Uyiosa Osagie Aigbe, Joseph Onyeka Emegha, Lucky Evbuomwan, Bamikole Olaleye Akinsehinde, Olusoji Anthony Ayeleso, Rout George Kerry, Benedict Okundaye, Atala Bihari Jena, Francis Jesmar P Montalbo, Grace Jokthan, Aizebeoje Balogun Vincent, Ahmed El Nemr",
-    title: "Environmental Applications of Magnetic Sorbents",
-    book: "Environmental Applications of Magnetic Sorbents",
-    year: "2024",
-    pages: "pp. 8-1 – 8-15",
-    publisher: "IOP Publishing",
-    isbn: "978-0-7503-5909-2",
-    url: "https://iopscience.iop.org/book/edit/978-0-7503-5909-2"
-  },
-  {
-    authors: "FJP Montalbo et al.",
-    title:
-      "The challenges of, and perspectives on adsorption applications for environmental sustainability",
-    book: "Adsorption Applications for Environmental Sustainability",
-    year: "2023",
-    publisher: "IOP Publishing",
-    isbn: "978-0-7503-5598-8",
-    url: "https://iopscience.iop.org/book/edit/978-0-7503-5598-8.pdf"
-  }
-];
-
-// News posts (easy content management: add newest items here).
-const newsData = [
-  {
-    date: "2026-05-05",
-    title: "National Spotlight: Recognized in OneNews Stanford Scientists Feature",
-    summary: "I was highlighted in OneNews’ coverage of the Stanford global scientist rankings—reinforcing my standing as an internationally recognized Filipino researcher contributing high-impact AI and biomedical signal processing work.",
-    tags: ["media-feature", "stanford-top-2%", "research-impact"],
-    link: "https://www.onenews.ph/articles/phl-has-fewest-scientists-in-asean-stanford-list",
-    linkLabel: "Read feature",
-    pinned: true
-  },
-  {
-    date: "2023-10-22",
-    title: "ICBSP 2023: Selected as One of the Best Presenters",
-    summary: "At ICBSP 2023, my presentation was selected among the conference’s best presenters—reflecting the clarity, novelty, and applied value of my research in biomedical imaging and AI.",
-    tags: ["best-presenter", "international-conference", "ai-research"],
-    link: "https://www.icbsp.org/icbsp2023.html",
-    linkLabel: "Conference page",
-    pinned: true
-  }
-];
-
-const profileContext = `
-Name: Dr. Francis Jesmar P. Montalbo
-Roles: Associate Professor, Research Scientist, AI & Deep Learning Specialist, Software Engineer
-Affiliation: Batangas State University
-Research: medical imaging AI, deep learning, biomedical signal processing, computer vision
-Education: Doctorate in Information Technology (Technological Institute of the Philippines-Manila)
-Selected Achievements: OneNews Stanford scientists feature; ICBSP 2023 best presenter
-Use only this profile context plus on-page publications/news data. If asked outside scope, politely refuse.
-`;
+const { journalData, conferenceData, chapterData, newsData, profileContext } = window.SiteData || {};
 
 // Mapping of publishers to custom badge classes
 const publisherBadgeMap = {
@@ -484,6 +79,9 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
   const clearButton = document.getElementById(clearId);
   const resultsCount = document.getElementById(resultsCountId);
   const countSpan = document.getElementById(countId);
+  if (!container || !searchInput || !yearSelect || !publisherSelect || !sortSelect || !clearButton) {
+    return;
+  }
 
   // Populate year dropdown with unique years
   const years = Array.from(new Set(normalizedData.map((d) => d.year))).sort((a, b) => b - a);
@@ -648,38 +246,33 @@ function initializePublications() {
 
 function initializeNews() {
   const list = document.getElementById('news-list');
-  const search = document.getElementById('news-search');
-  const yearFilter = document.getElementById('news-year-filter');
-  const clearBtn = document.getElementById('news-clear');
   const count = document.getElementById('news-count');
 
-  if (!list || !search || !yearFilter || !clearBtn || !count) return;
+  if (!list || !count) return;
 
   const sorted = [...newsData].sort((a, b) => {
     if (Boolean(b.pinned) !== Boolean(a.pinned)) return b.pinned ? 1 : -1;
     return new Date(b.date) - new Date(a.date);
   });
 
-  const years = Array.from(new Set(sorted.map((n) => new Date(n.date).getFullYear()))).sort((a, b) => b - a);
-  years.forEach((year) => {
-    const opt = document.createElement('option');
-    opt.value = String(year);
-    opt.textContent = String(year);
-    yearFilter.appendChild(opt);
-  });
-
   function render(items) {
     list.innerHTML = '';
-    items.forEach((item) => {
+    items.forEach((item, index) => {
       const tags = (item.tags || []).map((tag) => `<span class="badge badge-default">#${tag}</span>`).join(' ');
       const article = document.createElement('article');
+      const summaryId = `news-expanded-${index}-${item.date}`.replace(/[^a-zA-Z0-9-_]/g, '');
       article.className = 'publication-card';
       article.innerHTML = `
         <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
-          <div>
+          <div class="w-full">
+            ${item.image ? `<img src="${item.image}" alt="${item.imageAlt || item.title}" class="w-full max-h-72 object-cover rounded-lg border border-primary mb-3" loading="lazy" />` : ''}
             <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
             <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
             <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            <details class="mt-3">
+              <summary class="cursor-pointer text-sm text-accent">Expand: detailed summary</summary>
+              <p id="${summaryId}" class="text-sm text-gray-300 mt-2">${item.expandedSummary || item.summary}</p>
+            </details>
             <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
           </div>
           ${item.link ? `<a href="${item.link}" target="_blank" class="badge badge-code whitespace-nowrap mt-1">${item.linkLabel || 'Read more'}</a>` : ''}
@@ -688,132 +281,18 @@ function initializeNews() {
     });
     count.textContent = `${items.length} post${items.length === 1 ? '' : 's'}`;
   }
-
-  function apply() {
-    const term = search.value.trim().toLowerCase();
-    const selectedYear = yearFilter.value;
-    const filtered = sorted.filter((item) => {
-      const year = String(new Date(item.date).getFullYear());
-      const haystack = `${item.title} ${item.summary} ${(item.tags || []).join(' ')}`.toLowerCase();
-      return (selectedYear === 'all' || selectedYear === year) && haystack.includes(term);
-    });
-    render(filtered);
-  }
-
-  search.addEventListener('input', apply);
-  yearFilter.addEventListener('change', apply);
-  clearBtn.addEventListener('click', () => {
-    search.value = '';
-    yearFilter.value = 'all';
-    apply();
-  });
-
-  apply();
-}
-
-function initializeChatbot() {
-  const messages = document.getElementById('chatbot-messages');
-  const input = document.getElementById('chatbot-input');
-  const send = document.getElementById('chatbot-send');
-  const chips = document.querySelectorAll('.chatbot-chip');
-  if (!messages || !input || !send) return;
-
-  const allWorks = [
-    ...journalData.map((w) => ({ ...w, type: 'Journal' })),
-    ...conferenceData.map((w) => ({ ...w, type: 'Conference' })),
-    ...chapterData.map((w) => ({ ...w, type: 'Chapter' }))
-  ];
-
-  function addBubble(text, role = 'assistant') {
-    const bubble = document.createElement('div');
-    bubble.className = role === 'user'
-      ? 'max-w-[85%] ml-auto rounded-lg px-3 py-2 bg-accent2 text-dark'
-      : 'max-w-[85%] rounded-lg px-3 py-2 bg-tertiary text-gray-100';
-    bubble.textContent = text;
-    messages.appendChild(bubble);
-    messages.scrollTop = messages.scrollHeight;
-  }
-
-  function fallbackAnswer(question) {
-    const q = question.toLowerCase();
-    if (!q.includes('francis') && /(who are you|weather|politics|stock|bitcoin|movie|recipe)/.test(q)) {
-      return 'I can only answer questions specifically about Francis Jesmar P. Montalbo and his profile/work.';
-    }
-    if (q.includes('who is') || q.includes('bio') || q.includes('introduce')) {
-      return 'Dr. Francis Jesmar P. Montalbo is an Associate Professor, Research Scientist, AI & Deep Learning Specialist, and Software Engineer affiliated with Batangas State University.';
-    }
-    if (q.includes('research') || q.includes('area') || q.includes('expert')) {
-      return 'Francis focuses on medical imaging AI, deep learning, biomedical signal processing, and computer vision, with applications in diagnostics and healthcare.';
-    }
-    if (q.includes('recognition') || q.includes('award') || q.includes('best presenter') || q.includes('stanford')) {
-      return 'Notable recognitions include being featured in OneNews for Stanford scientist rankings and being selected as one of the best presenters at ICBSP 2023.';
-    }
-    if (q.includes('recent') || q.includes('publication') || q.includes('paper')) {
-      const latest = [...journalData].sort((a, b) => Number(b.year) - Number(a.year)).slice(0, 3)
-        .map((p) => `• ${p.year}: ${p.title}`).join('\n');
-      return `Here are recent works:\n${latest}`;
-    }
-    if (q.includes('conference') || q.includes('presenter')) {
-      const conf = conferenceData.slice(0, 3).map((c) => `• ${c.year}: ${c.title}`).join('\n');
-      return `Selected conference works:\n${conf}`;
-    }
-    if (q.includes('news') || q.includes('feature') || q.includes('recognition')) {
-      const highlights = newsData.map((n) => `• ${n.date}: ${n.title}`).join('\n');
-      return `Recent highlights:\n${highlights}`;
-    }
-    const matched = allWorks.filter((item) => {
-      const blob = `${item.title} ${item.authors || ''} ${item.journal || ''} ${item.venue || ''}`.toLowerCase();
-      return q.split(/\s+/).some((t) => t.length > 4 && blob.includes(t));
-    }).slice(0, 3);
-    if (matched.length) {
-      return `I found these related works:\n${matched.map((m) => `• [${m.type}] ${m.year}: ${m.title}`).join('\n')}`;
-    }
-    return 'I can help with Francis’ profile, publications, recognitions, affiliations, and research expertise. Please ask within those topics.';
-  }
-
-  async function ask() {
-    const question = input.value.trim();
-    if (!question) return;
-    addBubble(question, 'user');
-    input.value = '';
-    addBubble('Thinking…');
-    const thinkingBubble = messages.lastElementChild;
-    send.disabled = true;
-    try {
-      const grounding = `PROFILE:\n${profileContext}\n\nNEWS:\n${newsData.map((n) => `${n.date} - ${n.title}`).join('\n')}\n\nWORKS:\n${allWorks.slice(0, 60).map((w) => `${w.year} | ${w.title}`).join('\n')}`;
-      const llmPrompt = `You are Francis AI, a professional profile assistant.\nRules:\n1) Answer only about Francis Jesmar P. Montalbo.\n2) Use only the provided grounding data.\n3) If not in data, clearly say it is not available.\n\n${grounding}\n\nUser question: ${question}`;
-      const response = await fetch(`https://text.pollinations.ai/${encodeURIComponent(llmPrompt)}`);
-      if (!response.ok) throw new Error('Cloud LLM unavailable');
-      const text = (await response.text()).trim();
-      thinkingBubble.textContent = text || fallbackAnswer(question);
-    } catch (err) {
-      thinkingBubble.textContent = fallbackAnswer(question);
-    } finally {
-      send.disabled = false;
-    }
-  }
-
-  send.addEventListener('click', ask);
-  input.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') ask();
-  });
-  chips.forEach((chip) => {
-    chip.addEventListener('click', () => {
-      input.value = chip.dataset.question || '';
-      ask();
-    });
-  });
+  render(sorted);
 }
 
 // Run initialisation immediately or defer to DOMContentLoaded
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
-    initializePublications();
-    initializeNews();
-    initializeChatbot();
+    try { initializePublications(); } catch (e) { console.error('Publications init failed:', e); }
+    try { initializeNews(); } catch (e) { console.error('News init failed:', e); }
+    try { initializeChatbot(); } catch (e) { console.error('Chatbot init failed:', e); }
   });
 } else {
-  initializePublications();
-  initializeNews();
-  initializeChatbot();
+  try { initializePublications(); } catch (e) { console.error('Publications init failed:', e); }
+  try { initializeNews(); } catch (e) { console.error('News init failed:', e); }
+  try { initializeChatbot(); } catch (e) { console.error('Chatbot init failed:', e); }
 }


### PR DESCRIPTION
### Motivation
- Provide a modular, maintainable chatbot backed by on-page structured data and improve UX by replacing the embedded chatbot card with a floating chat widget.
- Move large publication/news datasets out of `js/script.js` into a centralized `js/data.js` to separate concerns and reduce bundle size.
- Add a resilient local fallback for the assistant so the site remains interactive when the external LLM or network requests fail.
- Clean duplicate resource includes and add a favicon for better HTML hygiene and faster load.

### Description
- Added a new data module `js/data.js` exposing `window.SiteData` which contains `journalData`, `conferenceData`, `chapterData`, `newsData`, and `profileContext` for use by other scripts.
- Introduced `js/chatbot.js` which implements the floating chat widget, UI wiring, RAG-style retrieval (`retrieveContext`), LLM call wrapper (`callLLM`), live-metrics snapshot fetcher (`fetchLiveMetricsSnapshot`), and a robust local fallback (`buildLocalFallback`); it initializes via `initializeChatbot` on DOM ready.
- Refactored `index.html` to remove the inline chatbot card and news search controls, add a floating action button (`#chatbot-fab`), a collapsible `#chatbot-widget` markup, a favicon link, and replaced duplicate external includes; added inline fallback wiring to guarantee widget open/close and basic message handling.
- Updated `js/script.js` to import datasets from `window.SiteData`, simplify initialization, improve defensive checks (guarding DOM elements), enhance news rendering (images, details, safe IDs), and call `initializePublications`, `initializeNews`, and `initializeChatbot` inside try/catch blocks.