### PR TITLE
Update News: replace placeholders with real images, change Expand → Read More, add SEO microdata/JSON-LD

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -386,8 +386,8 @@ const newsData = [
     tags: ["dost-funded", "atlantis-project", "automated-greenhouse", "software-engineering", "agri-innovation"],
     link: "https://www.pcaarrd.dost.gov.ph/index.php/quick-information-dispatch-qid-articles/dost-atlantis-project-developed-an-automated-greenhouse-for-lettuce-and-tilapia",
     linkLabel: "Read DOST feature",
-    image: "assets/img/experience.jpg",
-    imageAlt: "DOST ATLANTIS project feature and innovation milestone",
+    image: "assets/img/project_atlantis_francis_montalbo_inventor_scientist_engineer_inventor_ceo.png",
+    imageAlt: "DOST ATLANTIS automated greenhouse innovation led by Dr. Francis Jesmar P. Montalbo",
     pinned: true
   },
   {
@@ -398,8 +398,8 @@ const newsData = [
     tags: ["scopus-h-index", "research-impact", "batangas-state-university", "faculty-recognition"],
     link: "https://www.facebook.com/photo?fbid=1389710493174025&set=pcb.1389717616506646",
     linkLabel: "View announcement",
-    image: "assets/img/achievements.jpg",
-    imageAlt: "Faculty recognized for Scopus h-index and research impact",
+    image: "assets/img/francismontalbo_publication_top_hindex_achievement_recognition_award_2026.jpg",
+    imageAlt: "Batangas State University recognition for Scopus h-index and research impact in 2026",
     pinned: true
   },
   {
@@ -422,8 +422,8 @@ const newsData = [
     tags: ["best-presenter", "international-conference", "ai-research"],
     link: "https://www.icbsp.org/icbsp2023.html",
     linkLabel: "Conference page",
-    image: "assets/img/experience.jpg",
-    imageAlt: "Dr. Francis Jesmar P. Montalbo international conference and research experience photo",
+    image: "assets/img/francis_montalb_best_research_paper_presented_2023_ICBSP2023BP2.jpg",
+    imageAlt: "ICBSP 2023 Best Presenter recognition of Dr. Francis Jesmar P. Montalbo",
     pinned: true
   }
 ];

--- a/js/script.js
+++ b/js/script.js
@@ -277,15 +277,17 @@ function initializeNews() {
       const article = document.createElement('article');
       const summaryId = `news-expanded-${index}-${item.date}`.replace(/[^a-zA-Z0-9-_]/g, '');
       article.className = 'publication-card';
+      article.setAttribute('itemscope', '');
+      article.setAttribute('itemtype', 'https://schema.org/NewsArticle');
       article.innerHTML = `
         <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
           <div class="w-full">
-            ${item.image ? `<img src="${item.image}" alt="${item.imageAlt || item.title}" class="w-full max-h-72 object-cover rounded-lg border border-primary mb-3" loading="lazy" />` : ''}
-            <p class="text-xs text-accent2">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
-            <h3 class="text-lg font-semibold mt-1">${item.title}</h3>
-            <p class="text-sm text-gray-200 mt-2">${item.summary}</p>
+            ${item.image ? `<img src="${item.image}" alt="${item.imageAlt || item.title}" class="w-full max-h-72 object-cover rounded-lg border border-primary mb-3" loading="lazy" itemprop="image" />` : ''}
+            <p class="text-xs text-accent2"><time datetime="${item.date}" itemprop="datePublished">${new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</time>${item.pinned ? ' · <strong>Featured</strong>' : ''}</p>
+            <h3 class="text-lg font-semibold mt-1" itemprop="headline">${item.title}</h3>
+            <p class="text-sm text-gray-200 mt-2" itemprop="description">${item.summary}</p>
             <details class="mt-3">
-              <summary class="cursor-pointer text-sm text-accent">Expand: detailed summary</summary>
+              <summary class="cursor-pointer text-sm text-accent">Read More: detailed summary</summary>
               <p id="${summaryId}" class="text-sm text-gray-300 mt-2">${item.expandedSummary || item.summary}</p>
             </details>
             <div class="flex flex-wrap gap-2 mt-3">${tags}</div>
@@ -306,6 +308,38 @@ function initializeNews() {
     count.textContent = `${items.length} post${items.length === 1 ? '' : 's'}`;
   }
   render(sorted);
+
+  const newsJsonLd = {
+    "@context": "https://schema.org",
+    "@graph": sorted.map((item) => ({
+      "@type": "NewsArticle",
+      headline: item.title,
+      description: item.summary,
+      datePublished: item.date,
+      dateModified: item.date,
+      image: item.image ? new URL(item.image, window.location.origin).href : undefined,
+      url: item.link || window.location.href,
+      keywords: (item.tags || []).join(', '),
+      author: {
+        "@type": "Person",
+        name: "Dr. Francis Jesmar P. Montalbo"
+      },
+      publisher: {
+        "@type": "Person",
+        name: "Dr. Francis Jesmar P. Montalbo"
+      }
+    }))
+  };
+
+  let newsStructuredData = document.getElementById('news-structured-data');
+  if (!newsStructuredData) {
+    newsStructuredData = document.createElement('script');
+    newsStructuredData.id = 'news-structured-data';
+    newsStructuredData.type = 'application/ld+json';
+    document.head.appendChild(newsStructuredData);
+  }
+  newsStructuredData.textContent = JSON.stringify(newsJsonLd);
+
 }
 
 // Run initialisation immediately or defer to DOMContentLoaded


### PR DESCRIPTION
### Motivation
- Replace generic placeholder images in the News section with the provided, news-specific assets so each post shows the intended image. 
- Improve clarity of the expandable summary label by changing “Expand” to “Read More.”
- Make the News section more discoverable to search engines by adding semantic markup and structured data.

### Description
- Replaced image paths for the ATLANTIS, Scopus h-index recognition, and ICBSP 2023 news entries in `js/data.js` with `assets/img/project_atlantis_francis_montalbo_inventor_scientist_engineer_inventor_ceo.png`, `assets/img/francismontalbo_publication_top_hindex_achievement_recognition_award_2026.jpg`, and `assets/img/francis_montalb_best_research_paper_presented_2023_ICBSP2023BP2.jpg` respectively.
- Changed the expandable summary label text in `js/script.js` from `Expand: detailed summary` to `Read More: detailed summary`.
- Added Schema.org `NewsArticle` microdata attributes (`itemscope`, `itemtype`) and `itemprop` annotations (`image`, `datePublished`, `headline`, `description`) to rendered news cards in `js/script.js`.
- Injected JSON-LD structured data as a `script#news-structured-data` built from the `newsData` array to expose each news item as a `NewsArticle` in the page head.