### PR TITLE
Unify Socials icon styling across profile links

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,39 +162,27 @@
             </h3>
             <ul class="space-y-3">
               <li class="flex items-center gap-3">
-                <span class="flex items-center justify-center w-8 h-8 rounded-full bg-accent2">
-                  <span class="iconify text-primaryDark" data-icon="mdi:github"></span>
-                </span>
+                <i class="iconify text-accent2 text-2xl" data-icon="simple-icons:github"></i>
                 <a href="https://www.github.com/francismontalbo" rel="noopener noreferrer" target="_blank" class="ui-btn ui-btn-sm">GitHub</a>
               </li>
               <li class="flex items-center gap-3">
-                <span class="flex items-center justify-center w-8 h-8 rounded-full bg-accent2">
-                  <span class="iconify text-primaryDark" data-icon="simple-icons:kaggle"></span>
-                </span>
+                <i class="iconify text-accent2 text-2xl" data-icon="simple-icons:kaggle"></i>
                 <a href="https://www.kaggle.com/francismon" target="_blank" class="ui-btn ui-btn-sm">Kaggle</a>
               </li>
               <li class="flex items-center gap-3">
-                <span class="flex items-center justify-center w-8 h-8 rounded-full bg-accent2">
-                  <span class="iconify text-primaryDark" data-icon="mdi:linkedin"></span>
-                </span>
+                <i class="iconify text-accent2 text-2xl" data-icon="simple-icons:linkedin"></i>
                 <a href="https://www.linkedin.com/in/sirjmmontalbo/" target="_blank" class="ui-btn ui-btn-sm">LinkedIn</a>
               </li>
               <li class="flex items-center gap-3">
-                <span class="flex items-center justify-center w-8 h-8 rounded-full bg-accent2">
-                  <span class="iconify text-primaryDark" data-icon="simple-icons:researchgate"></span>
-                </span>
+                <i class="iconify text-accent2 text-2xl" data-icon="simple-icons:researchgate"></i>
                 <a href="https://www.researchgate.net/profile/Francis_Jesmar_Montalbo" target="_blank" class="ui-btn ui-btn-sm">ResearchGate</a>
               </li>
               <li class="flex items-center gap-3">
-                <span class="flex items-center justify-center w-8 h-8 rounded-full bg-accent2">
-                  <span class="iconify text-primaryDark" data-icon="mdi:facebook"></span>
-                </span>
+                <i class="iconify text-accent2 text-2xl" data-icon="simple-icons:facebook"></i>
                 <a href="https://www.facebook.com/docfrancismontalbo" target="_blank" class="ui-btn ui-btn-sm">Facebook</a>
               </li>
               <li class="flex items-center gap-3">
-                <span class="flex items-center justify-center w-8 h-8 rounded-full bg-accent2">
-                  <span class="iconify text-primaryDark" data-icon="mdi:twitter"></span>
-                </span>
+                <i class="iconify text-accent2 text-2xl" data-icon="simple-icons:x"></i>
                 <a href="https://x.com/francismontalbo" target="_blank" class="ui-btn ui-btn-sm">X (Twitter)</a>
               </li>
             </ul>


### PR DESCRIPTION
### Motivation
- The Socials panel used mixed icon markups and circular filled wrappers which made entries look visually inconsistent. 
- The change aims to present all platform links with a single color/size inline icon treatment to match other profile groups. 
- This improves visual cohesion and hover/spacing consistency across the Socials section.

### Description
- Replaced circular `span` wrappers and mixed icon fills for GitHub, Kaggle, LinkedIn, ResearchGate, Facebook, and X with inline `iconify` elements using `text-accent2 text-2xl` in `index.html`. 
- Removed the `rounded-full bg-accent2` container markup for those entries so icons follow the same style used elsewhere in the Socials lists. 
- No CSS changes were required because the existing `#socials` icon rules apply to the new markup. 
- Only `index.html` was modified to standardize the icon markup.

### Testing
- Verified the updated icon classes and lack of `rounded-full` wrappers with `rg -n "rounded-full bg-accent2|text-primaryDark\" data-icon|simple-icons:x|simple-icons:github" index.html`, which found the new `simple-icons` usages. 
- Confirmed the modified block contents with `nl -ba index.html | sed -n '150,225p'` to ensure the list items now include inline `iconify` icons. 
- Created the PR via repository tooling and local checks indicate the expected HTML lines were updated and render-ready.