### PR TITLE
Enhance publications list: improved card layout, badges, access indicators, and citation copying

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -148,3 +148,49 @@ footer{padding-top:2.2rem!important;padding-bottom:2.2rem!important}
   border: 1px solid #1d4ed8 !important;
   font-weight: 600 !important;
 }
+
+
+/* Works cards: even heights + better space usage */
+#works .tab-content .grid{align-items:stretch}
+#works .work-item{display:flex}
+#works .publication-card{height:100%;display:flex;width:100%}
+#works .publication-card .card-body{height:100%;display:flex;flex-direction:column;gap:.35rem}
+#works .publication-card .card-title{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;min-height:4.1em}
+#works .publication-card .card-text{font-size:.93rem;line-height:1.5;display:-webkit-box;-webkit-line-clamp:6;-webkit-box-orient:vertical;overflow:hidden}
+#works .work-badges{border-top:1px solid var(--border);padding-top:.65rem}
+#works .work-badges .badge{display:inline-flex;align-items:center;padding:.45rem .6rem;font-weight:600}
+
+/* Works badge contrast/readability fixes */
+#works .work-badges .badge{
+  color:#0f172a !important;
+  background:#e2e8f0 !important;
+  border:1px solid #cbd5e1 !important;
+}
+#works .work-badges .badge i{color:inherit !important}
+#works .work-badges .badge-elsevier{background:#fff3e6 !important;color:#9a3412 !important;border-color:#fdba74 !important}
+#works .work-badges .badge-springer{background:#e0f2fe !important;color:#0c4a6e !important;border-color:#7dd3fc !important}
+#works .work-badges .badge-ieee{background:#dbeafe !important;color:#1e3a8a !important;border-color:#93c5fd !important}
+#works .work-badges .badge-acm{background:#ede9fe !important;color:#4c1d95 !important;border-color:#c4b5fd !important}
+#works .work-badges .badge-code{background:#dcfce7 !important;color:#14532d !important;border-color:#86efac !important}
+
+#works .work-badges .badge-read-publication{background:#2563eb !important;color:#fff !important;border-color:#1d4ed8 !important;font-weight:700;box-shadow:0 2px 8px rgba(37,99,235,.28)}
+#works .work-badges .badge-read-publication:hover{background:#1d4ed8 !important;color:#fff !important;transform:translateY(-1px)}
+
+#works .work-badges .cite-menu{position:relative;display:inline-block}
+#works .work-badges .badge-cite{list-style:none;cursor:pointer;background:#0f766e !important;color:#fff !important;border-color:#0d9488 !important}
+#works .work-badges .cite-menu[open] .cite-options{display:flex}
+#works .work-badges .cite-options{display:none;position:absolute;z-index:20;top:110%;left:0;background:#fff;border:1px solid var(--border);border-radius:10px;padding:.35rem;gap:.35rem;box-shadow:0 8px 20px rgba(0,0,0,.12)}
+#works .work-badges .cite-options .badge{white-space:nowrap}
+
+#works .work-badges .badge-access-open{background:#dcfce7 !important;color:#166534 !important;border-color:#86efac !important}
+#works .work-badges .badge-access-closed{background:#fee2e2 !important;color:#991b1b !important;border-color:#fca5a5 !important}
+
+#works .work-badges .badge-static{cursor:default;opacity:.92}
+#works .work-badges .badge-action{cursor:pointer;text-decoration:underline;text-underline-offset:2px}
+#works .work-badges .badge-action:hover{filter:brightness(.96)}
+#works .work-badges .badge-static::after{content:""}
+
+#works .work-badges{display:flex;flex-direction:column;gap:.55rem}
+#works .work-badges-group{align-items:center}
+#works .work-badges-divider{height:1px;background:linear-gradient(90deg,rgba(148,163,184,.15),rgba(148,163,184,.75),rgba(148,163,184,.15));margin:.1rem 0 .05rem}
+#works .work-badges-group-actions .badge-action{box-shadow:0 1px 3px rgba(2,6,23,.12)}

--- a/js/data.js
+++ b/js/data.js
@@ -8,6 +8,7 @@ const journalData = [
     title:
       "MHADFormer: A Cost-Efficient Multiscale Hybrid Transformer Mixer Model for Automating Alzheimer’s Disease Diagnosis from MRI Scans",
     journal: "Applied Soft Computing",
+    access: "closed",
     volume: "114624",
     date: "2026",
     doi: "10.1016/j.asoc.2026.114624",
@@ -21,6 +22,7 @@ const journalData = [
     title:
       "TUMbRAIN: A transformer with a unified mobile residual attention inverted network for diagnosing brain tumors from magnetic resonance scans",
     journal: "Neurocomputing",
+    access: "closed",
     volume: "611",
     date: "January 1, 2025",
     doi: "10.1016/j.neucom.2024.128583",
@@ -34,6 +36,7 @@ const journalData = [
     title:
       "DySARNet: a lightweight self‑attention deep learning model for diagnosing dysarthria from speech recordings",
     journal: "Multimedia Tools and Applications",
+    access: "closed",
     date: "August 31, 2024",
     doi: "10.1007/s11042-024-20053-w",
     doiUrl: "https://doi.org/10.1007/s11042-024-20053-w",
@@ -45,6 +48,7 @@ const journalData = [
     title:
       "A Multi‑Vision Monitoring Framework for Simultaneous Real‑Time Unmanned Aerial Monitoring of Farmer Activity and Crop Health",
     journal: "Smart Agricultural Technology",
+    access: "open",
     date: "May 16, 2024",
     doi: "10.1016/j.atech.2024.100466",
     doiUrl: "https://doi.org/10.1016/j.atech.2024.100466",
@@ -78,6 +82,7 @@ const journalData = [
     title:
       "Automating Mosquito Taxonomy by Compressing and Enhancing a Feature Fused EfficientNet with Knowledge Distillation and a Novel Residual Skip Block",
     journal: "MethodsX",
+    access: "open",
     date: "February 14, 2023",
     doi: "10.1016/j.mex.2023.102072",
     doiUrl: "https://doi.org/10.1016/j.mex.2023.102072",
@@ -90,6 +95,7 @@ const journalData = [
     title:
       "Machine‑based Mosquito Taxonomy with a Lightweight Network‑fused Efficient Dual ConvNet with Residual Learning and Knowledge Distillation",
     journal: "Applied Soft Computing",
+    access: "closed",
     date: "December 16, 2022",
     doi: "10.1016/j.asoc.2022.109913",
     doiUrl: "https://doi.org/10.1016/j.asoc.2022.109913",
@@ -101,6 +107,7 @@ const journalData = [
     title:
       "Fusing Compressed Deep ConvNets with a Self‑Normalizing Residual Block and Alpha Dropout for a Cost‑Efficient Classification and Diagnosis of Gastrointestinal Tract Diseases",
     journal: "MethodsX",
+    access: "open",
     date: "November 2022",
     doi: "10.1016/j.mex.2022.101925",
     doiUrl: "https://doi.org/10.1016/j.mex.2022.101925",
@@ -159,6 +166,7 @@ const journalData = [
     title:
       "Truncating Fined‑Tuned Vision‑Based Models to Lightweight Deployable Diagnostic Tools for SARS‑CoV‑2 Infected Chest X‑Rays and CT‑Scans",
     journal: "Multimedia Tools and Applications",
+    access: "closed",
     date: "2022",
     doi: "10.1007/s11042-022-12484-0",
     doiUrl: "https://doi.org/10.1007/s11042-022-12484-0",
@@ -183,6 +191,7 @@ const journalData = [
     title:
       "Truncating a Densely Connected Convolutional Neural Network with Partial Layer Freezing and Feature Fusion for Diagnosing COVID‑19 from Chest X‑Rays",
     journal: "MethodsX",
+    access: "open",
     volume: "8, 101408",
     date: "2021",
     doi: "10.1016/j.mex.2021.101408",
@@ -251,7 +260,8 @@ const conferenceData = [
     pages: "pp. 35–40",
     doi: "10.1109/ICSPC63060.2024.10862188",
     doiUrl: "https://doi.org/10.1109/ICSPC63060.2024.10862188",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2024,
@@ -264,7 +274,8 @@ const conferenceData = [
     pages: "pp. 273–278",
     doi: "10.1109/ICICoS62600.2024.10636920",
     doiUrl: "https://doi.org/10.1109/ICICoS62600.2024.10636920",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2023,
@@ -275,7 +286,8 @@ const conferenceData = [
       "Proceedings of the 2023 8th International Conference on Biomedical Imaging, Signal Processing",
     doi: "10.1145/3634875.3634878",
     doiUrl: "https://doi.org/10.1145/3634875.3634878",
-    publisher: "ACM"
+    publisher: "ACM",
+    access: "closed"
   },
   {
     year: 2021,
@@ -287,7 +299,8 @@ const conferenceData = [
     pages: "",
     doi: "",
     doiUrl: "",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2020,
@@ -298,7 +311,8 @@ const conferenceData = [
     pages: "pp. 3–7",
     doi: "10.1109/ISET49818.2020.00011",
     doiUrl: "https://doi.org/10.1109/ISET49818.2020.00011",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2020,
@@ -311,7 +325,8 @@ const conferenceData = [
     pages: "pp. 213–218",
     doi: "10.1109/CSPA48992.2020.9068683",
     doiUrl: "https://doi.org/10.1109/CSPA48992.2020.9068683",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2019,
@@ -324,7 +339,8 @@ const conferenceData = [
     pages: "pp. 305–310",
     doi: "10.1109/ICCIKE47802.2019.9004359",
     doiUrl: "https://doi.org/10.1109/ICCIKE47802.2019.9004359",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2019,
@@ -336,7 +352,8 @@ const conferenceData = [
     pages: "pp. 396–401",
     doi: "10.1109/ICSEngT.2019.8906433",
     doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906433",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2019,
@@ -348,7 +365,8 @@ const conferenceData = [
     pages: "pp. 431–436",
     doi: "10.1109/ICSEngT.2019.8906310",
     doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906310",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   }
 ];
 

--- a/js/script.js
+++ b/js/script.js
@@ -49,8 +49,38 @@ const conferenceIconMap = {
 
 // Academicons icons for PubMed and access type
 const pubmedIconClass = 'ai ai-pubmed';
-const openAccessIconClass = 'ai ai-open-access';
-const closedAccessIconClass = 'ai ai-closed-access';
+const openAccessIconClass = 'fa-solid fa-unlock-keyhole';
+const closedAccessIconClass = 'fa-solid fa-lock';
+
+
+function escapeHtml(text) {
+  return String(text || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildCitation(entry, format = 'IEEE') {
+  const authors = entry.authors || 'Unknown Author';
+  const title = entry.title || 'Untitled';
+  const year = entry.year || 'n.d.';
+  const source = entry.journal || entry.venue || entry.book || '';
+  const pages = entry.pages ? `, ${entry.pages}` : '';
+  const volume = entry.volume ? `, vol. ${entry.volume}` : '';
+  const doi = entry.doi ? ` doi:${entry.doi}` : '';
+  const link = entry.doiUrl || entry.publicationUrl || entry.pubmedUrl || '';
+
+  if (format === 'APA') {
+    return `${authors} (${year}). ${title}. ${source}${doi ? `. ${doi}` : ''}${link ? ` ${link}` : ''}`.trim();
+  }
+  if (format === 'MLA') {
+    return `${authors}. "${title}." ${source}, ${year}${volume}${pages}${doi ? `, ${doi}` : ''}${link ? `, ${link}` : ''}.`;
+  }
+  // IEEE default
+  return `${authors}, "${title}," ${source}${volume}${pages}, ${year}${doi ? `, ${doi}` : ''}${link ? `, ${link}` : ''}.`;
+}
 
 /**
  * Populate a publications section with data, search box and year filter.
@@ -123,12 +153,13 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
     lastFiltered = items;
     container.innerHTML = '';
     items.slice(0, visibleCount).forEach((entry) => {
-      const col = document.createElement('div');
-      col.className = 'col-md-6';
+      const col = document.createElement('article');
+      col.className = 'work-item';
       let html = '<div class="publication-card card h-100">';
-      html += '<div class="card-body">';
+      html += '<div class="card-body d-flex flex-column">';
       html += `<h5 class="card-title">${entry.title}</h5>`;
       html += `<p class="text-sm text-accent2 mb-2"><i class="fa-regular fa-calendar me-1"></i>${entry.year}</p>`;
+      html += '<div class="work-meta mb-2">';
       // Build citation text
       let citation = `${entry.authors}, “${entry.title},” `;
       if (entry.journal) {
@@ -145,31 +176,51 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
       }
       citation += '.';
       html += `<p class="card-text">${citation}</p>`;
-      // Build badges
-      html += '<div class="d-flex flex-wrap gap-2 mt-3 pt-1">';
+      html += '</div>';
+      const publicationUrl = entry.publicationUrl || entry.doiUrl || entry.pubmedUrl || '';
+      const publicationLabel = entry.doiUrl ? 'Read Publication' : (entry.pubmedUrl ? 'View on PubMed' : 'View Publication');
+      // Build badges (grouped by interaction type)
+      html += '<div class="work-badges mt-3 pt-1 mt-auto">';
+      html += '<div class="work-badges-group work-badges-group-actions d-flex flex-wrap gap-2">';
+      if (publicationUrl) {
+        html += `<a href="${publicationUrl}" target="_blank" rel="noopener noreferrer" class="badge badge-read-publication badge-action" aria-label="Open publication"><i class="fa-solid fa-book-open-reader me-1"></i>${publicationLabel}</a>`;
+      }
+      const ieeeCite = escapeHtml(buildCitation(entry, 'IEEE'));
+      const apaCite = escapeHtml(buildCitation(entry, 'APA'));
+      const mlaCite = escapeHtml(buildCitation(entry, 'MLA'));
+      html += `<details class="cite-menu"><summary class="badge badge-cite"><i class="fa-solid fa-quote-left me-1"></i>Cite</summary><div class="cite-options"><button type="button" class="badge badge-default cite-copy badge-action" data-citation="${ieeeCite}">Copy IEEE</button><button type="button" class="badge badge-default cite-copy badge-action" data-citation="${apaCite}">Copy APA</button><button type="button" class="badge badge-default cite-copy badge-action" data-citation="${mlaCite}">Copy MLA</button></div></details>`;
+      html += '</div>';
+      html += '<div class="work-badges-divider" role="separator" aria-label="Publication metadata"></div>';
+      html += '<div class="work-badges-group work-badges-group-static d-flex flex-wrap gap-2">';
+      // Publication type badge
+      if (entry.workType) {
+        html += `<span class="badge badge-default badge-static"><i class="fa-regular fa-file-lines me-1"></i>${entry.workType}</span>`;
+      }
       // Code badge with Font Awesome GitHub icon and custom colour
       if (entry.codeUrl) {
-        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code" aria-label="Code repository"><i class="fab fa-github fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
+        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code badge-action" aria-label="Code repository"><i class="fab fa-github fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
       }
       // Publisher badge with Academicon icon if available
       if (entry.publisher) {
         const pubClass = publisherBadgeMap[entry.publisher] || 'badge-default';
         const pubIcon = publisherIconMap[entry.publisher];
         if (pubIcon) {
-          html += `<span class="badge ${pubClass}"><i class="${pubIcon} me-1"></i>${entry.publisher}</span>`;
+          html += `<span class="badge ${pubClass} badge-static"><i class="${pubIcon} me-1"></i>${entry.publisher}</span>`;
         } else {
-          html += `<span class="badge ${pubClass}">${entry.publisher}</span>`;
+          html += `<span class="badge ${pubClass} badge-static">${entry.publisher}</span>`;
         }
       }
       // PubMed badge if provided
       if (entry.pubmedUrl) {
-        html += `<a href="${entry.pubmedUrl}" target="_blank" class="badge badge-default"><i class="${pubmedIconClass} me-1"></i>PubMed</a>`;
+        html += `<a href="${entry.pubmedUrl}" target="_blank" class="badge badge-default badge-action"><i class="${pubmedIconClass} me-1"></i>PubMed</a>`;
       }
       // Access badge (open or closed; default closed)
       if (entry.access === 'open') {
-        html += `<span class="badge badge-default"><i class="${openAccessIconClass} me-1"></i>Open Access</span>`;
+        html += `<span class="badge badge-access-open badge-static"><i class="${openAccessIconClass} me-1"></i>Open Access</span>`;
+      } else if (entry.access === 'closed') {
+        html += `<span class="badge badge-access-closed badge-static"><i class="${closedAccessIconClass} me-1"></i>Subscription</span>`;
       } else {
-        html += `<span class="badge badge-default"><i class="${closedAccessIconClass} me-1"></i>Closed Access</span>`;
+        html += `<span class="badge badge-default badge-static"><i class="fa-solid fa-circle-question me-1"></i>Access: Check publisher</span>`;
       }
       // Conference venue icons (if venue contains keywords)
       if (entry.venue) {
@@ -181,9 +232,24 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
         });
       }
       html += '</div>';
+      html += '</div>';
       html += '</div></div>';
+
       col.innerHTML = html;
       container.appendChild(col);
+      col.querySelectorAll('.cite-copy').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          const citationText = btn.getAttribute('data-citation') || '';
+          try {
+            await navigator.clipboard.writeText(citationText);
+            const old = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(() => { btn.textContent = old; }, 1200);
+          } catch (e) {
+            btn.textContent = 'Copy failed';
+          }
+        });
+      });
     });
 
     let loadMoreBtn = container.parentElement.querySelector(`[data-load-more-for="${containerId}"]`);
@@ -242,15 +308,19 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
 // Initialise publications once DOM is ready
 function initializePublications() {
   const { journalData, conferenceData, chapterData } = getSiteData();
+  const typedJournals = journalData.map((item) => ({ ...item, workType: item.workType || 'Journal Article' }));
+  const typedConferences = conferenceData.map((item) => ({ ...item, workType: item.workType || 'Conference Paper' }));
+  const typedChapters = chapterData.map((item) => ({ ...item, journal: item.book, workType: item.workType || 'Book Chapter' }));
+
   const allData = [
-    ...journalData.map((item) => ({ ...item })),
-    ...conferenceData.map((item) => ({ ...item })),
-    ...chapterData.map((item) => ({ ...item, journal: item.book }))
+    ...typedJournals,
+    ...typedConferences,
+    ...typedChapters
   ];
   initSection(allData, 'all-publications', 'all-search', 'all-year-filter', 'all-count', 'all-publisher-filter', 'all-sort', 'all-clear-filters', 'all-results-count');
-  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
-  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
-  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
+  initSection(typedJournals, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
+  initSection(typedConferences, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
+  initSection(typedChapters, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
 
   // AOS animations
   if (typeof AOS !== 'undefined') {


### PR DESCRIPTION
### Motivation
- Improve readability and consistency of the publications/works listing by standardizing card heights, badge contrast, and metadata layout. 
- Surface access information (open/closed) and make citations easier to copy/share for each publication.

### Description
- Added new UI styles in `css/styles.css` for `.publication-card`, `.work-item`, and `.work-badges` to enforce even heights, flexible card body layout, badge contrast, and interaction states.
- Annotated publications and conferences with `access` in `js/data.js` for multiple entries to indicate `open` or `closed` access where available.
- Reworked `js/script.js` by replacing access icon classes, adding `escapeHtml` and `buildCitation` helpers, and significantly refactoring the card renderer to: use `article.work-item`, render a `publicationUrl` action (`Read Publication`), show publisher/conference icons as static badges, add an interactive `Cite` menu with `Copy IEEE/APA/MLA` buttons, and provide accessible access badges with distinct styles for open/closed/unknown access.
- Added clipboard copy handling for citation buttons, default `workType` assignment for `journal`, `conference`, and `chapter` items, and updated initialization to pass typed datasets into `initSection`.