### PR TITLE
Enhance Works section: UI/UX, accessibility, badges, citations, SCImago and responsive polish

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -148,3 +148,235 @@ footer{padding-top:2.2rem!important;padding-bottom:2.2rem!important}
   border: 1px solid #1d4ed8 !important;
   font-weight: 600 !important;
 }
+
+
+/* Works cards: even heights + better space usage */
+#works .tab-content .grid{align-items:stretch}
+#works .work-item{display:flex}
+#works .publication-card{height:100%;display:flex;width:100%}
+#works .publication-card .card-body{height:100%;display:flex;flex-direction:column;gap:.35rem}
+#works .publication-card .card-title{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;min-height:4.1em}
+#works .publication-card .card-text{font-size:.93rem;line-height:1.55;display:block;overflow:visible;word-break:normal;overflow-wrap:anywhere}
+#works .work-badges{border-top:1px solid var(--border);padding-top:.65rem}
+#works .work-badges .badge{display:inline-flex;align-items:center;padding:.45rem .6rem;font-weight:600}
+
+/* Works badge contrast/readability fixes */
+#works .work-badges .badge{
+  color:#0f172a !important;
+  background:#e2e8f0 !important;
+  border:1px solid #cbd5e1 !important;
+}
+#works .work-badges .badge i{color:inherit !important}
+#works .work-badges .badge-elsevier{background:#fff3e6 !important;color:#9a3412 !important;border-color:#fdba74 !important}
+#works .work-badges .badge-springer{background:#e0f2fe !important;color:#0c4a6e !important;border-color:#7dd3fc !important}
+#works .work-badges .badge-ieee{background:#dbeafe !important;color:#1e3a8a !important;border-color:#93c5fd !important}
+#works .work-badges .badge-acm{background:#ede9fe !important;color:#4c1d95 !important;border-color:#c4b5fd !important}
+#works .work-badges .badge-code{background:#dcfce7 !important;color:#14532d !important;border-color:#86efac !important}
+
+#works .work-badges .badge-read-publication{background:#2563eb !important;color:#fff !important;border-color:#1d4ed8 !important;font-weight:700;box-shadow:0 2px 8px rgba(37,99,235,.28)}
+#works .work-badges .badge-read-publication:hover{background:#1d4ed8 !important;color:#fff !important;transform:translateY(-1px)}
+
+#works .work-badges .cite-menu{position:relative;display:inline-block}
+#works .work-badges .badge-cite{list-style:none;cursor:pointer;background:#0f766e !important;color:#fff !important;border-color:#0d9488 !important}
+#works .work-badges .cite-menu[open] .cite-options{display:flex}
+#works .work-badges .cite-options{display:none;position:absolute;z-index:20;top:110%;left:0;background:#fff;border:1px solid var(--border);border-radius:10px;padding:.35rem;gap:.35rem;box-shadow:0 8px 20px rgba(0,0,0,.12)}
+#works .work-badges .cite-options .badge{white-space:nowrap}
+
+#works .work-badges .badge-access-open{background:#dcfce7 !important;color:#166534 !important;border-color:#86efac !important}
+#works .work-badges .badge-access-closed{background:#fee2e2 !important;color:#991b1b !important;border-color:#fca5a5 !important}
+
+#works .work-badges .badge-static{cursor:default;opacity:.92}
+#works .work-badges .badge-action{cursor:pointer;text-decoration:underline;text-underline-offset:2px}
+#works .work-badges .badge-action:hover{filter:brightness(.96)}
+#works .work-badges .badge-static::after{content:""}
+
+#works .work-badges{display:flex;flex-direction:column;gap:.55rem}
+#works .work-badges-group{align-items:center}
+#works .work-badges-divider{height:1px;background:linear-gradient(90deg,rgba(148,163,184,.15),rgba(148,163,184,.75),rgba(148,163,184,.15));margin:.1rem 0 .05rem}
+#works .work-badges-group-actions .badge-action{box-shadow:0 1px 3px rgba(2,6,23,.12)}
+
+#works .work-badges{background:#f8fafc;border:1px solid #e2e8f0;border-radius:10px;padding:.6rem}
+#works .work-badges-section-label{font-size:.68rem;letter-spacing:.08em;text-transform:uppercase;color:#64748b;font-weight:700;margin:.05rem 0}
+#works .work-badges-group-actions{padding-bottom:.35rem;border-bottom:1px dashed #cbd5e1}
+#works .work-badges-group-static{padding-top:.2rem;align-items:flex-start}
+#works .work-badges-divider{display:none}
+
+#works .work-badges .badge-cite:hover{background:#0d9488 !important;transform:translateY(-1px);box-shadow:0 2px 8px rgba(13,148,136,.25)}
+#works .work-badges .badge-cite:focus-visible{outline:2px solid #14b8a6;outline-offset:2px}
+
+
+#works .publication-card .card-title{
+  font-family:"Times New Roman", Times, serif !important;
+  font-weight:700 !important;
+  text-align:center !important;
+}
+
+#works .work-widget{display:flex;justify-content:flex-start;align-items:flex-start;margin:0;flex:0 0 auto}
+#works .work-widget a{display:flex;align-items:center;justify-content:center;width:84px;height:84px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;box-shadow:0 1px 4px rgba(2,6,23,.08);padding:.25rem;overflow:hidden}
+#works .work-widget img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block}
+#works .work-widget a:hover{transform:translateY(-1px);transition:transform .15s ease, box-shadow .15s ease;box-shadow:0 4px 10px rgba(2,6,23,.12)}
+
+#works .work-citation-layout{display:grid;grid-template-columns:84px minmax(0,1fr);gap:.65rem;align-items:start}
+#works .work-citation-layout .card-text{text-align:left !important;margin:0}
+
+
+
+/* Works responsive polish across devices/browsers */
+#works .publication-card .card-title,
+#works .publication-card .card-text{
+  overflow-wrap:anywhere;
+}
+#works .work-badges{gap:.5rem}
+#works .work-badges-group{row-gap:.4rem}
+#works .work-badges .badge{max-width:100%}
+#works .work-badges .cite-options{max-width:min(92vw,420px);flex-wrap:wrap}
+#works .work-citation-layout{grid-template-columns:84px minmax(0,1fr)}
+
+@media (max-width: 991.98px){
+  #works .publication-card{padding:1rem !important}
+  #works .work-badges{padding:.5rem}
+}
+
+@media (max-width: 767.98px){
+  #works .publication-card .card-title{
+    font-size:1.04rem !important;
+    line-height:1.3;
+    display:block !important;
+    -webkit-line-clamp:unset !important;
+    -webkit-box-orient:unset !important;
+    overflow:visible !important;
+    min-height:0 !important;
+  }
+  #works .publication-card .card-text{font-size:.9rem;line-height:1.5}
+  #works .work-citation-layout{grid-template-columns:72px minmax(0,1fr);gap:.55rem;align-items:start}
+  #works .work-widget a{width:72px;height:72px}
+  #works .work-badges-section-label{font-size:.64rem}
+}
+
+@media (max-width: 479.98px){
+  #works .work-citation-layout{grid-template-columns:64px minmax(0,1fr);gap:.5rem;align-items:start}
+  #works .work-widget{order:0;margin:0}
+  #works .work-widget a{width:64px;height:64px}
+  #works .work-badges{padding:.45rem}
+  #works .work-badges-group-actions,
+  #works .work-badges-group-static{gap:.35rem !important}
+  #works .work-badges .badge{font-size:.72rem;padding:.38rem .5rem}
+  #works .work-badges .cite-options{position:absolute;box-shadow:0 8px 20px rgba(0,0,0,.12);border-style:solid;margin-top:0}
+}
+
+
+/* Make Cite action more noticeable */
+#works .work-badges .badge-cite{
+  position:relative;
+  animation:citePulse 2.2s ease-in-out infinite;
+}
+#works .work-badges .badge-cite::after{
+  content:"";
+  position:absolute;
+  inset:-4px;
+  border-radius:12px;
+  border:2px solid rgba(13,148,136,.35);
+  animation:citeRing 2.2s ease-out infinite;
+  pointer-events:none;
+}
+#works .work-badges .cite-menu:hover .badge-cite,
+#works .work-badges .cite-menu[open] .badge-cite{
+  animation:none;
+}
+#works .work-badges .cite-menu:hover .badge-cite::after,
+#works .work-badges .cite-menu[open] .badge-cite::after{
+  animation:none;
+  opacity:.5;
+}
+@keyframes citePulse{
+  0%,100%{transform:translateY(0) scale(1)}
+  50%{transform:translateY(-1px) scale(1.03)}
+}
+@keyframes citeRing{
+  0%{transform:scale(.92);opacity:.55}
+  70%{transform:scale(1.1);opacity:0}
+  100%{transform:scale(1.1);opacity:0}
+}
+@media (prefers-reduced-motion: reduce){
+  #works .work-badges .badge-cite,
+  #works .work-badges .badge-cite::after{animation:none !important}
+}
+
+
+/* Load more button clarity */
+#works [data-load-more-for]{
+  display:inline-flex;
+  align-items:center;
+  gap:.4rem;
+  border-radius:999px !important;
+}
+#works [data-load-more-for] .load-more-meta{
+  font-weight:500;
+  opacity:.88;
+}
+@media (max-width: 575.98px){
+  #works [data-load-more-for]{font-size:.82rem !important;padding:.52rem .82rem !important}
+  #works [data-load-more-for] .load-more-meta{display:none}
+}
+
+
+/* Centered load-more with clean animation */
+#works [data-load-more-for]{
+  margin-left:auto;
+  margin-right:auto;
+  justify-content:center;
+  transition:transform .2s ease, box-shadow .2s ease, background-color .2s ease;
+  animation:loadMoreFloatIn .45s ease both;
+}
+#works [data-load-more-for]:hover{
+  transform:translateY(-1px);
+  box-shadow:0 6px 16px rgba(37,99,235,.22);
+}
+#works [data-load-more-for]:active{
+  transform:translateY(0);
+}
+@keyframes loadMoreFloatIn{
+  from{opacity:0;transform:translateY(6px) scale(.98)}
+  to{opacity:1;transform:translateY(0) scale(1)}
+}
+@media (prefers-reduced-motion: reduce){
+  #works [data-load-more-for]{animation:none;transition:none}
+}
+
+#works [data-load-more-for]{display:flex !important;width:fit-content;margin:1rem auto 0 auto !important;text-align:center}
+#works [data-load-more-for].load-more-animate{animation:loadMoreFloatIn .45s ease both, loadMoreGlow 2.8s ease-in-out infinite}
+@keyframes loadMoreGlow{0%,100%{box-shadow:0 4px 10px rgba(37,99,235,.12)}50%{box-shadow:0 8px 18px rgba(37,99,235,.25)}}
+@media (prefers-reduced-motion: reduce){#works [data-load-more-for].load-more-animate{animation:none !important}}
+
+#works [data-load-more-for][hidden]{display:none !important}
+#works [data-load-more-for]:not([hidden]){animation:loadMoreIdle 3.2s ease-in-out infinite}
+@keyframes loadMoreIdle{0%,100%{transform:translateY(0)}50%{transform:translateY(-1px)}}
+@media (prefers-reduced-motion: reduce){#works [data-load-more-for]:not([hidden]){animation:none !important}}
+
+
+/* Works category tabs: clearer arrangement + active state */
+#works .works-tabs{
+  display:grid !important;
+  grid-template-columns:repeat(4,minmax(0,1fr));
+  gap:.7rem !important;
+  max-width:760px;
+  margin:0 auto 1.2rem auto !important;
+}
+#works .works-tabs .tab{
+  width:100%;
+  justify-content:center;
+  text-align:center;
+  border:1px solid #bfdbfe !important;
+  background:#eaf1ff !important;
+  color:#1e3a8a !important;
+}
+#works .works-tabs .tab.is-active{
+  background:#1d4ed8 !important;
+  border-color:#1e40af !important;
+  color:#ffffff !important;
+  box-shadow:0 6px 16px rgba(29,78,216,.28);
+}
+#works .works-tabs .tab:not(.is-active):hover{background:#dbeafe !important}
+@media (max-width: 767.98px){
+  #works .works-tabs{grid-template-columns:repeat(2,minmax(0,1fr));max-width:420px}
+}

--- a/index.html
+++ b/index.html
@@ -375,11 +375,11 @@
           <p class="text-sm text-gray-300 mb-6">Publications are arranged by type and sorted by latest year/date for easier browsing. For the most updated and more accurate research profile (including citation metrics), view Google Scholar: <a href="https://scholar.google.com/citations?user=PV8dJDkAAAAJ&hl=en" target="_blank" class="text-accent2 hover:text-accent underline">PV8dJDkAAAAJ</a> and Scopus: <a href="https://www.scopus.com/authid/detail.uri?authorId=57221928564" target="_blank" class="text-accent2 hover:text-accent underline">Author ID 57221928564</a>.</p>
           <!-- Removed static Top Works section to rely on dynamic publications -->
           <!-- Tabs -->
-          <div class="tabs flex flex-col sm:flex-row gap-4 mb-8">
-            <button class="tab btn btn-primary btn-sm" data-target="all-tab">All</button>
-            <button class="tab btn btn-primary btn-sm" data-target="journal-tab">Journals</button>
-            <button class="tab btn btn-primary btn-sm" data-target="conference-tab">Conferences</button>
-            <button class="tab btn btn-primary btn-sm" data-target="chapters-tab">Chapters</button>
+          <div class="tabs works-tabs" role="tablist" aria-label="Publication categories">
+            <button class="tab btn btn-primary btn-sm is-active" data-target="all-tab" role="tab" aria-selected="true">All</button>
+            <button class="tab btn btn-primary btn-sm" data-target="journal-tab" role="tab" aria-selected="false">Journals</button>
+            <button class="tab btn btn-primary btn-sm" data-target="conference-tab" role="tab" aria-selected="false">Conferences</button>
+            <button class="tab btn btn-primary btn-sm" data-target="chapters-tab" role="tab" aria-selected="false">Chapters</button>
           </div>
           <!-- All -->
           <div id="all-tab" class="tab-content">

--- a/js/data.js
+++ b/js/data.js
@@ -8,6 +8,9 @@ const journalData = [
     title:
       "MHADFormer: A Cost-Efficient Multiscale Hybrid Transformer Mixer Model for Automating Alzheimer’s Disease Diagnosis from MRI Scans",
     journal: "Applied Soft Computing",
+    access: "closed",
+    scimagoUrl: "https://www.scimagojr.com/journalsearch.php?q=18136&tip=sid&exact=no",
+    scimagoImg: "https://www.scimagojr.com/journal_img.php?id=18136",
     volume: "114624",
     date: "2026",
     doi: "10.1016/j.asoc.2026.114624",
@@ -21,6 +24,7 @@ const journalData = [
     title:
       "TUMbRAIN: A transformer with a unified mobile residual attention inverted network for diagnosing brain tumors from magnetic resonance scans",
     journal: "Neurocomputing",
+    access: "closed",
     volume: "611",
     date: "January 1, 2025",
     doi: "10.1016/j.neucom.2024.128583",
@@ -34,6 +38,7 @@ const journalData = [
     title:
       "DySARNet: a lightweight self‑attention deep learning model for diagnosing dysarthria from speech recordings",
     journal: "Multimedia Tools and Applications",
+    access: "closed",
     date: "August 31, 2024",
     doi: "10.1007/s11042-024-20053-w",
     doiUrl: "https://doi.org/10.1007/s11042-024-20053-w",
@@ -45,6 +50,7 @@ const journalData = [
     title:
       "A Multi‑Vision Monitoring Framework for Simultaneous Real‑Time Unmanned Aerial Monitoring of Farmer Activity and Crop Health",
     journal: "Smart Agricultural Technology",
+    access: "open",
     date: "May 16, 2024",
     doi: "10.1016/j.atech.2024.100466",
     doiUrl: "https://doi.org/10.1016/j.atech.2024.100466",
@@ -78,6 +84,7 @@ const journalData = [
     title:
       "Automating Mosquito Taxonomy by Compressing and Enhancing a Feature Fused EfficientNet with Knowledge Distillation and a Novel Residual Skip Block",
     journal: "MethodsX",
+    access: "open",
     date: "February 14, 2023",
     doi: "10.1016/j.mex.2023.102072",
     doiUrl: "https://doi.org/10.1016/j.mex.2023.102072",
@@ -90,6 +97,9 @@ const journalData = [
     title:
       "Machine‑based Mosquito Taxonomy with a Lightweight Network‑fused Efficient Dual ConvNet with Residual Learning and Knowledge Distillation",
     journal: "Applied Soft Computing",
+    access: "closed",
+    scimagoUrl: "https://www.scimagojr.com/journalsearch.php?q=18136&tip=sid&exact=no",
+    scimagoImg: "https://www.scimagojr.com/journal_img.php?id=18136",
     date: "December 16, 2022",
     doi: "10.1016/j.asoc.2022.109913",
     doiUrl: "https://doi.org/10.1016/j.asoc.2022.109913",
@@ -101,6 +111,7 @@ const journalData = [
     title:
       "Fusing Compressed Deep ConvNets with a Self‑Normalizing Residual Block and Alpha Dropout for a Cost‑Efficient Classification and Diagnosis of Gastrointestinal Tract Diseases",
     journal: "MethodsX",
+    access: "open",
     date: "November 2022",
     doi: "10.1016/j.mex.2022.101925",
     doiUrl: "https://doi.org/10.1016/j.mex.2022.101925",
@@ -159,6 +170,7 @@ const journalData = [
     title:
       "Truncating Fined‑Tuned Vision‑Based Models to Lightweight Deployable Diagnostic Tools for SARS‑CoV‑2 Infected Chest X‑Rays and CT‑Scans",
     journal: "Multimedia Tools and Applications",
+    access: "closed",
     date: "2022",
     doi: "10.1007/s11042-022-12484-0",
     doiUrl: "https://doi.org/10.1007/s11042-022-12484-0",
@@ -183,6 +195,7 @@ const journalData = [
     title:
       "Truncating a Densely Connected Convolutional Neural Network with Partial Layer Freezing and Feature Fusion for Diagnosing COVID‑19 from Chest X‑Rays",
     journal: "MethodsX",
+    access: "open",
     volume: "8, 101408",
     date: "2021",
     doi: "10.1016/j.mex.2021.101408",
@@ -251,7 +264,8 @@ const conferenceData = [
     pages: "pp. 35–40",
     doi: "10.1109/ICSPC63060.2024.10862188",
     doiUrl: "https://doi.org/10.1109/ICSPC63060.2024.10862188",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2024,
@@ -264,7 +278,8 @@ const conferenceData = [
     pages: "pp. 273–278",
     doi: "10.1109/ICICoS62600.2024.10636920",
     doiUrl: "https://doi.org/10.1109/ICICoS62600.2024.10636920",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2023,
@@ -275,7 +290,8 @@ const conferenceData = [
       "Proceedings of the 2023 8th International Conference on Biomedical Imaging, Signal Processing",
     doi: "10.1145/3634875.3634878",
     doiUrl: "https://doi.org/10.1145/3634875.3634878",
-    publisher: "ACM"
+    publisher: "ACM",
+    access: "closed"
   },
   {
     year: 2021,
@@ -287,7 +303,8 @@ const conferenceData = [
     pages: "",
     doi: "",
     doiUrl: "",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2020,
@@ -298,7 +315,8 @@ const conferenceData = [
     pages: "pp. 3–7",
     doi: "10.1109/ISET49818.2020.00011",
     doiUrl: "https://doi.org/10.1109/ISET49818.2020.00011",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2020,
@@ -311,7 +329,8 @@ const conferenceData = [
     pages: "pp. 213–218",
     doi: "10.1109/CSPA48992.2020.9068683",
     doiUrl: "https://doi.org/10.1109/CSPA48992.2020.9068683",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2019,
@@ -324,7 +343,8 @@ const conferenceData = [
     pages: "pp. 305–310",
     doi: "10.1109/ICCIKE47802.2019.9004359",
     doiUrl: "https://doi.org/10.1109/ICCIKE47802.2019.9004359",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2019,
@@ -336,7 +356,8 @@ const conferenceData = [
     pages: "pp. 396–401",
     doi: "10.1109/ICSEngT.2019.8906433",
     doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906433",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   },
   {
     year: 2019,
@@ -348,7 +369,8 @@ const conferenceData = [
     pages: "pp. 431–436",
     doi: "10.1109/ICSEngT.2019.8906310",
     doiUrl: "https://doi.org/10.1109/ICSEngT.2019.8906310",
-    publisher: "IEEE"
+    publisher: "IEEE",
+    access: "closed"
   }
 ];
 

--- a/js/main.js
+++ b/js/main.js
@@ -29,11 +29,13 @@
       const tabContents = document.querySelectorAll('.tab-content');
       tabs.forEach(tab => {
         tab.addEventListener('click', () => {
-          // Remove active state from all tabs and hide all contents
-          tabs.forEach(t => t.classList.remove('bg-tertiary'));
+          tabs.forEach(t => {
+            t.classList.remove('is-active');
+            t.setAttribute('aria-selected', 'false');
+          });
           tabContents.forEach(c => c.classList.add('hidden'));
-          // Add active state to clicked tab and show corresponding content
-          tab.classList.add('bg-tertiary');
+          tab.classList.add('is-active');
+          tab.setAttribute('aria-selected', 'true');
           const target = tab.getAttribute('data-target');
           document.getElementById(target).classList.remove('hidden');
         });

--- a/js/script.js
+++ b/js/script.js
@@ -49,8 +49,56 @@ const conferenceIconMap = {
 
 // Academicons icons for PubMed and access type
 const pubmedIconClass = 'ai ai-pubmed';
-const openAccessIconClass = 'ai ai-open-access';
-const closedAccessIconClass = 'ai ai-closed-access';
+const openAccessIconClass = 'fa-solid fa-unlock-keyhole';
+const closedAccessIconClass = 'fa-solid fa-lock';
+const workTypeIconMap = {
+  'Journal Article': 'fa-regular fa-newspaper',
+  'Conference Paper': 'fa-solid fa-users-rectangle',
+  'Book Chapter': 'fa-solid fa-book-open'
+};
+
+
+const scimagoByJournal = {
+  'Applied Soft Computing': { id: '18136' },
+  'Neurocomputing': { id: '24807' },
+  'Multimedia Tools and Applications': { id: '25627' },
+  'Smart Agricultural Technology': { id: '21101111783' },
+  'Biomedical Signal Processing and Control': { id: '4700152237' },
+  'MethodsX': { id: '21100317906' },
+  'Machine Vision and Applications': { id: '12984' },
+  'Environmental Science and Pollution Research': { id: '23918' },
+  'Journal of Process Mechanical Engineering': { id: '20408' }
+};
+
+
+function escapeHtml(text) {
+  return String(text || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildCitation(entry, format = 'IEEE') {
+  const authors = entry.authors || 'Unknown Author';
+  const title = entry.title || 'Untitled';
+  const year = entry.year || 'n.d.';
+  const source = entry.journal || entry.venue || entry.book || '';
+  const pages = entry.pages ? `, ${entry.pages}` : '';
+  const volume = entry.volume ? `, vol. ${entry.volume}` : '';
+  const doi = entry.doi ? ` doi:${entry.doi}` : '';
+  const link = entry.doiUrl || entry.publicationUrl || entry.pubmedUrl || '';
+
+  if (format === 'APA') {
+    return `${authors} (${year}). ${title}. ${source}${doi ? `. ${doi}` : ''}${link ? ` ${link}` : ''}`.trim();
+  }
+  if (format === 'MLA') {
+    return `${authors}. "${title}." ${source}, ${year}${volume}${pages}${doi ? `, ${doi}` : ''}${link ? `, ${link}` : ''}.`;
+  }
+  // IEEE default
+  return `${authors}, "${title}," ${source}${volume}${pages}, ${year}${doi ? `, ${doi}` : ''}${link ? `, ${link}` : ''}.`;
+}
 
 /**
  * Populate a publications section with data, search box and year filter.
@@ -113,6 +161,26 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
     publisherSelect.appendChild(opt);
   });
 
+  function repopulateYearOptions(items) {
+    if (!yearSelect) return;
+    const current = yearSelect.value || 'all';
+    yearSelect.innerHTML = '';
+    const allOpt = document.createElement('option');
+    allOpt.value = 'all';
+    allOpt.textContent = 'All Years';
+    yearSelect.appendChild(allOpt);
+
+    const dynamicYears = Array.from(new Set(items.map((d) => d.year).filter(Boolean))).sort((a, b) => b - a);
+    dynamicYears.forEach((y) => {
+      const opt = document.createElement('option');
+      opt.value = y;
+      opt.textContent = y;
+      yearSelect.appendChild(opt);
+    });
+
+    yearSelect.value = dynamicYears.some((y) => String(y) === current) ? current : 'all';
+  }
+
   // Show total count if applicable
   if (countSpan) {
     countSpan.textContent = normalizedData.length;
@@ -123,12 +191,13 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
     lastFiltered = items;
     container.innerHTML = '';
     items.slice(0, visibleCount).forEach((entry) => {
-      const col = document.createElement('div');
-      col.className = 'col-md-6';
+      const col = document.createElement('article');
+      col.className = 'work-item';
       let html = '<div class="publication-card card h-100">';
-      html += '<div class="card-body">';
+      html += '<div class="card-body d-flex flex-column">';
       html += `<h5 class="card-title">${entry.title}</h5>`;
       html += `<p class="text-sm text-accent2 mb-2"><i class="fa-regular fa-calendar me-1"></i>${entry.year}</p>`;
+      html += '<div class="work-meta mb-2">';
       // Build citation text
       let citation = `${entry.authors}, “${entry.title},” `;
       if (entry.journal) {
@@ -144,32 +213,61 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
         citation += `, doi: <a href="${entry.doiUrl}" target="_blank">${entry.doi}</a>`;
       }
       citation += '.';
-      html += `<p class="card-text">${citation}</p>`;
-      // Build badges
-      html += '<div class="d-flex flex-wrap gap-2 mt-3 pt-1">';
+      const scimagoMeta = scimagoByJournal[entry.journal] || null;
+      const scimagoUrl = entry.scimagoUrl || (scimagoMeta ? `https://www.scimagojr.com/journalsearch.php?q=${scimagoMeta.id}&tip=sid` : '');
+      const scimagoImg = entry.scimagoImg || (scimagoMeta ? `https://www.scimagojr.com/journal_img.php?id=${scimagoMeta.id}` : '');
+      if (scimagoUrl && scimagoImg) {
+        html += `<div class="work-citation-layout"><div class="work-widget"><a href="${scimagoUrl}" target="_blank" rel="noopener noreferrer" title="SCImago Journal & Country Rank"><img src="${scimagoImg}" alt="SCImago Journal & Country Rank" loading="lazy" /></a></div><p class="card-text">${citation}</p></div>`;
+      } else {
+        html += `<p class="card-text">${citation}</p>`;
+      }
+      html += '</div>';
+      const publicationUrl = entry.publicationUrl || entry.doiUrl || entry.pubmedUrl || '';
+      const publicationLabel = entry.doiUrl ? 'Read Publication' : (entry.pubmedUrl ? 'View on PubMed' : 'View Publication');
+      // Build badges (grouped by interaction type)
+      html += '<div class="work-badges mt-3 pt-1 mt-auto">';
+      html += '<div class="work-badges-section-label">Actions</div>';
+      html += '<div class="work-badges-group work-badges-group-actions d-flex flex-wrap gap-2">';
+      if (publicationUrl) {
+        html += `<a href="${publicationUrl}" target="_blank" rel="noopener noreferrer" class="badge badge-read-publication badge-action" aria-label="Open publication"><i class="fa-solid fa-book-open-reader me-1"></i>${publicationLabel}</a>`;
+      }
+      const ieeeCite = escapeHtml(buildCitation(entry, 'IEEE'));
+      const apaCite = escapeHtml(buildCitation(entry, 'APA'));
+      const mlaCite = escapeHtml(buildCitation(entry, 'MLA'));
+      html += `<details class="cite-menu"><summary class="badge badge-cite"><i class="fa-solid fa-quote-left me-1"></i>Cite</summary><div class="cite-options"><button type="button" class="badge badge-default cite-copy badge-action" data-citation="${ieeeCite}">Copy IEEE</button><button type="button" class="badge badge-default cite-copy badge-action" data-citation="${apaCite}">Copy APA</button><button type="button" class="badge badge-default cite-copy badge-action" data-citation="${mlaCite}">Copy MLA</button></div></details>`;
       // Code badge with Font Awesome GitHub icon and custom colour
       if (entry.codeUrl) {
-        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code" aria-label="Code repository"><i class="fab fa-github fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
+        html += `<a href="${entry.codeUrl}" target="_blank" class="badge badge-code badge-action" aria-label="Code repository"><i class="fab fa-github fa-github me-1" style="color:#0B0F08;"></i>Code</a>`;
+      }
+      // PubMed badge if provided
+      if (entry.pubmedUrl) {
+        html += `<a href="${entry.pubmedUrl}" target="_blank" class="badge badge-default badge-action"><i class="${pubmedIconClass} me-1"></i>PubMed</a>`;
+      }
+      html += '</div>';
+      html += '<div class="work-badges-section-label">Details</div>';
+      html += '<div class="work-badges-group work-badges-group-static d-flex flex-wrap gap-2">';
+      // Publication type badge
+      if (entry.workType) {
+        const workTypeIcon = workTypeIconMap[entry.workType] || 'fa-regular fa-file-lines';
+        html += `<span class="badge badge-default badge-static"><i class="${workTypeIcon} me-1"></i>${entry.workType}</span>`;
       }
       // Publisher badge with Academicon icon if available
       if (entry.publisher) {
         const pubClass = publisherBadgeMap[entry.publisher] || 'badge-default';
         const pubIcon = publisherIconMap[entry.publisher];
         if (pubIcon) {
-          html += `<span class="badge ${pubClass}"><i class="${pubIcon} me-1"></i>${entry.publisher}</span>`;
+          html += `<span class="badge ${pubClass} badge-static"><i class="${pubIcon} me-1"></i>${entry.publisher}</span>`;
         } else {
-          html += `<span class="badge ${pubClass}">${entry.publisher}</span>`;
+          html += `<span class="badge ${pubClass} badge-static">${entry.publisher}</span>`;
         }
-      }
-      // PubMed badge if provided
-      if (entry.pubmedUrl) {
-        html += `<a href="${entry.pubmedUrl}" target="_blank" class="badge badge-default"><i class="${pubmedIconClass} me-1"></i>PubMed</a>`;
       }
       // Access badge (open or closed; default closed)
       if (entry.access === 'open') {
-        html += `<span class="badge badge-default"><i class="${openAccessIconClass} me-1"></i>Open Access</span>`;
+        html += `<span class="badge badge-access-open badge-static"><i class="${openAccessIconClass} me-1"></i>Open Access</span>`;
+      } else if (entry.access === 'closed') {
+        html += `<span class="badge badge-access-closed badge-static"><i class="${closedAccessIconClass} me-1"></i>Subscription</span>`;
       } else {
-        html += `<span class="badge badge-default"><i class="${closedAccessIconClass} me-1"></i>Closed Access</span>`;
+        html += `<span class="badge badge-default badge-static"><i class="fa-solid fa-circle-question me-1"></i>Access: Check publisher</span>`;
       }
       // Conference venue icons (if venue contains keywords)
       if (entry.venue) {
@@ -181,9 +279,25 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
         });
       }
       html += '</div>';
+      html += '</div>';
       html += '</div></div>';
+
       col.innerHTML = html;
       container.appendChild(col);
+      setupCitationMenuDismissal(col);
+      col.querySelectorAll('.cite-copy').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          const citationText = btn.getAttribute('data-citation') || '';
+          try {
+            await navigator.clipboard.writeText(citationText);
+            const old = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(() => { btn.textContent = old; }, 1200);
+          } catch (e) {
+            btn.textContent = 'Copy failed';
+          }
+        });
+      });
     });
 
     let loadMoreBtn = container.parentElement.querySelector(`[data-load-more-for="${containerId}"]`);
@@ -198,18 +312,37 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
       });
       container.parentElement.appendChild(loadMoreBtn);
     }
-    const hiddenCount = items.length - Math.min(items.length, visibleCount);
-    loadMoreBtn.style.display = hiddenCount > 0 ? 'inline-flex' : 'none';
-    loadMoreBtn.textContent = hiddenCount > 0 ? `Load more works (${hiddenCount} remaining)` : '';
+    const shownCount = Math.min(items.length, visibleCount);
+    const hiddenCount = items.length - shownCount;
+    loadMoreBtn.hidden = hiddenCount <= 0;
+    loadMoreBtn.style.display = hiddenCount > 0 ? 'flex' : 'none';
+    if (hiddenCount > 0) {
+      loadMoreBtn.classList.remove('load-more-animate');
+      void loadMoreBtn.offsetWidth;
+      loadMoreBtn.classList.add('load-more-animate');
+      const nextBatch = Math.min(INITIAL_VISIBLE, hiddenCount);
+      loadMoreBtn.innerHTML = `<i class="fa-solid fa-angles-down me-2" aria-hidden="true"></i>Load ${nextBatch} more works <span class="load-more-meta">(${shownCount} of ${items.length} shown)</span>`;
+      loadMoreBtn.setAttribute('aria-label', `Load ${nextBatch} more works. ${hiddenCount} remaining.`);
+      loadMoreBtn.title = `${hiddenCount} works remaining`;
+    } else {
+      loadMoreBtn.classList.remove('load-more-animate');
+      loadMoreBtn.innerHTML = '';
+      loadMoreBtn.removeAttribute('title');
+      loadMoreBtn.setAttribute('aria-label', '');
+    }
   }
 
   // Search and filter logic
   function applyFilter() {
     const term = (searchInput?.value || '').trim().toLowerCase();
-    const year = yearSelect?.value || 'all';
     const publisher = publisherSelect?.value || 'all';
     const sortMode = sortSelect?.value || 'latest';
-    const filtered = normalizedData.filter((entry) => {
+
+    const scopedByPublisher = normalizedData.filter((entry) => (publisher === 'all' || (entry.publisher || '') === publisher));
+    repopulateYearOptions(scopedByPublisher);
+
+    const year = yearSelect?.value || 'all';
+    const filtered = scopedByPublisher.filter((entry) => {
       const haystack = `${entry.title || ''} ${entry.authors || ''} ${entry.journal || ''} ${entry.venue || ''} ${entry.publisher || ''}`.toLowerCase();
       const matchesText = haystack.includes(term);
       const matchesYear = year === 'all' || String(entry.year) === year;
@@ -236,21 +369,55 @@ function initSection(data, containerId, searchId, filterId, countId, publisherFi
       applyFilter();
     });
   }
+
+
+  if (!container.dataset.citeOutsideBound) {
+    document.addEventListener('click', (event) => {
+      const openMenus = document.querySelectorAll('#works .cite-menu[open]');
+      openMenus.forEach((menu) => {
+        if (!menu.contains(event.target)) {
+          menu.removeAttribute('open');
+        }
+      });
+    });
+    container.dataset.citeOutsideBound = 'true';
+  }
+
   applyFilter();
 }
 
 // Initialise publications once DOM is ready
+
+function closeOtherCitationMenus(activeMenu) {
+  document.querySelectorAll('#works .cite-menu[open]').forEach((menu) => {
+    if (menu !== activeMenu) menu.removeAttribute('open');
+  });
+}
+
+function setupCitationMenuDismissal(scopeElement) {
+  const menus = scopeElement.querySelectorAll('.cite-menu');
+  menus.forEach((menu) => {
+    menu.addEventListener('toggle', () => {
+      if (menu.open) closeOtherCitationMenus(menu);
+    });
+  });
+}
+
 function initializePublications() {
   const { journalData, conferenceData, chapterData } = getSiteData();
+  const typedJournals = journalData.map((item) => ({ ...item, workType: item.workType || 'Journal Article' }));
+  const typedConferences = conferenceData.map((item) => ({ ...item, workType: item.workType || 'Conference Paper' }));
+  const typedChapters = chapterData.map((item) => ({ ...item, journal: item.book, workType: item.workType || 'Book Chapter' }));
+
   const allData = [
-    ...journalData.map((item) => ({ ...item })),
-    ...conferenceData.map((item) => ({ ...item })),
-    ...chapterData.map((item) => ({ ...item, journal: item.book }))
+    ...typedJournals,
+    ...typedConferences,
+    ...typedChapters
   ];
   initSection(allData, 'all-publications', 'all-search', 'all-year-filter', 'all-count', 'all-publisher-filter', 'all-sort', 'all-clear-filters', 'all-results-count');
-  initSection(journalData, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
-  initSection(conferenceData, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
-  initSection(chapterData, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
+  initSection(typedJournals, 'journal-publications', 'journal-search', 'journal-year-filter', 'journal-count', 'journal-publisher-filter', 'journal-sort', 'journal-clear-filters', 'journal-results-count');
+  initSection(typedConferences, 'conference-publications', 'conf-search', 'conf-year-filter', 'conf-count', 'conf-publisher-filter', 'conf-sort', 'conf-clear-filters', 'conf-results-count');
+  initSection(typedChapters, 'book-chapters', 'chapters-search', 'chapters-year-filter', 'chapters-count', 'chapters-publisher-filter', 'chapters-sort', 'chapters-clear-filters', 'chapters-results-count');
 
   // AOS animations
   if (typeof AOS !== 'undefined') {


### PR DESCRIPTION
### Motivation
- Modernize the "Works" (publications) section for improved readability, consistency, and discoverability across devices and assistive tech.
- Provide clearer publisher/access badges and actionable controls (read, cite, code) so visitors can quickly find and copy citations or open publication resources.
- Improve visual consistency and interaction affordances for the dynamic publications list (load-more, tabs, badges, widgets).

### Description
- Reworked HTML tabs for publications to use role/aria attributes and an `is-active` state for accessibility and clearer semantics in `index.html`.
- Extended `css/styles.css` with a large set of styles for the `#works` section including publication card layout, badge styles, responsive rules, load-more animations, citation menu visuals, and improved contrast/readability for badges.
- Enhanced publication data entries in `js/data.js` by adding `access` and optional `scimago` properties for some journals to enable richer UI (open/closed access and SCImago links/images).
- Substantially refactored `js/script.js` to build richer publication cards: SCImago widget, grouped action/detail badges, publisher icons, access state badges, work type badges, citation builders (IEEE/APA/MLA), accessible cite menu with copy-to-clipboard buttons, improved load-more behavior and labels, and helper utilities (`escapeHtml`, `buildCitation`, `setupCitationMenuDismissal`, etc.).
- Updated `js/main.js` tab switching logic to toggle `is-active` and `aria-selected` attributes instead of the previous class, improving keyboard/screen-reader behavior and consistent styling.
- Normalized publications data before initializing sections and added dynamic year repopulation when filtering by publisher, plus small UX polish like animating the load-more button when more items are available.